### PR TITLE
fix(gui): prevent prompt duplication when dragging split pane divider

### DIFF
--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -362,6 +362,11 @@ enum EventState {
     InProgressWithQueued(Option<PaneId>),
 }
 
+/// State tracked during a live split-divider drag.
+struct SplitDragState {
+    tab_id: TabId,
+}
+
 pub struct TermWindow {
     pub window: Option<Window>,
     pub config: ConfigHandle,
@@ -440,6 +445,9 @@ pub struct TermWindow {
 
     ui_items: Vec<UIItem>,
     dragging: Option<(UIItem, MouseEvent)>,
+    /// Tracks state during a live split-drag so we can defer PTY
+    /// notification until the drag ends.
+    split_drag_state: Option<SplitDragState>,
 
     modal: RefCell<Option<Rc<dyn Modal>>>,
 
@@ -783,6 +791,7 @@ impl TermWindow {
             semantic_zones: HashMap::new(),
             ui_items: vec![],
             dragging: None,
+            split_drag_state: None,
             last_ui_item: None,
             is_click_to_focus_window: false,
             key_table_state: KeyTableState::default(),

--- a/kaku-gui/src/termwindow/mouseevent.rs
+++ b/kaku-gui/src/termwindow/mouseevent.rs
@@ -130,7 +130,15 @@ impl super::TermWindow {
                     return;
                 }
                 if press == &MousePress::Left && self.dragging.take().is_some() {
-                    // Completed a drag
+                    // Completed a split drag: notify PTY of final sizes
+                    // using the tab_id captured at drag start.
+                    if let Some(state) = self.split_drag_state.take() {
+                        let mux = Mux::get();
+                        if let Some(tab) = mux.get_tab(state.tab_id) {
+                            tab.flush_pane_pty_sizes();
+                            context.invalidate();
+                        }
+                    }
                     return;
                 }
             }
@@ -261,17 +269,48 @@ impl super::TermWindow {
         context: &dyn WindowOps,
     ) {
         let mux = Mux::get();
-        let tab = match mux.get_active_tab_for_window(self.mux_window_id) {
-            Some(tab) => tab,
-            None => return,
+
+        // On the first drag event, capture the tab_id from the active tab.
+        // All subsequent frames (and the final release) use this tab_id
+        // so we always operate on the same tab even if tabs switch mid-drag.
+        let tab = if let Some(ref state) = self.split_drag_state {
+            match mux.get_tab(state.tab_id) {
+                Some(tab) => tab,
+                None => {
+                    // Tab was closed mid-drag; clear stale state and
+                    // fall back to the current active tab.
+                    self.split_drag_state = None;
+                    let tab = match mux.get_active_tab_for_window(self.mux_window_id) {
+                        Some(tab) => tab,
+                        None => return,
+                    };
+                    self.split_drag_state = Some(super::SplitDragState {
+                        tab_id: tab.tab_id(),
+                    });
+                    tab
+                }
+            }
+        } else {
+            let tab = match mux.get_active_tab_for_window(self.mux_window_id) {
+                Some(tab) => tab,
+                None => return,
+            };
+            self.split_drag_state = Some(super::SplitDragState {
+                tab_id: tab.tab_id(),
+            });
+            tab
         };
+
         let delta = match split.direction {
             SplitDirection::Horizontal => (x as isize).saturating_sub(split.left as isize),
             SplitDirection::Vertical => (y as isize).saturating_sub(split.top as isize),
         };
 
         if delta != 0 {
-            tab.resize_split_by(split.index, delta);
+            // Use visual-only resize during drag: updates terminal state
+            // for smooth content reflow but does NOT notify the PTY,
+            // so the shell won't receive rapid SIGWINCH signals.
+            tab.resize_split_by_visual(split.index, delta);
             if let Some(split) = tab.iter_splits().into_iter().nth(split.index) {
                 item.item_type = UIItemType::Split(split);
                 context.invalidate();

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -425,6 +425,11 @@ impl Pane for LocalPane {
         Ok(())
     }
 
+    fn resize_visual(&self, size: TerminalSize) -> Result<(), Error> {
+        self.terminal.lock().resize(size);
+        Ok(())
+    }
+
     fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
         Mux::get().record_input_for_current_identity();
         MutexGuard::map(self.writer.lock(), |writer| {

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -239,6 +239,13 @@ pub trait Pane: Downcast + Send + Sync {
     fn reader(&self) -> anyhow::Result<Option<Box<dyn std::io::Read + Send>>>;
     fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write>;
     fn resize(&self, size: TerminalSize) -> anyhow::Result<()>;
+    /// Resize terminal state only without notifying the PTY.
+    /// Used during live split-drag to provide smooth visual feedback
+    /// without sending rapid SIGWINCH to the shell.
+    /// The default implementation falls back to `resize`.
+    fn resize_visual(&self, size: TerminalSize) -> anyhow::Result<()> {
+        self.resize(size)
+    }
     /// Called as a hint that the pane is being resized as part of
     /// a zoom-to-fill-all-the-tab-space operation.
     fn set_zoomed(&self, _zoomed: bool) {}


### PR DESCRIPTION
## Summary

Fixes #10

- Dragging the split pane divider caused the shell prompt to duplicate/garble because every mouse-move event sent TIOCSWINSZ to the PTY (~60 SIGWINCH/sec)
- Decoupled terminal state resize from PTY notification during split drag: visual reflow happens in real-time, PTY is notified only once on mouse release
- Added `Pane::resize_visual()` trait method with safe default fallback for all pane types

## Changes

| File | Change |
|------|--------|
| `mux/src/pane.rs` | Add `resize_visual()` default trait method (falls back to `resize()`) |
| `mux/src/localpane.rs` | Override `resize_visual()`: only `terminal.resize()`, skip `pty.resize()` |
| `mux/src/tab.rs` | Add `resize_split_by_visual()`, `cascade_size_from_cursor_visual()`, `flush_pane_pty_sizes()` |
| `kaku-gui/src/termwindow/mod.rs` | Add `SplitDragState { tab_id }` to track drag lifecycle |
| `kaku-gui/src/termwindow/mouseevent.rs` | Use visual-only resize during drag; flush PTY on release; pin to captured tab_id with fallback recovery |

## Test plan

- [ ] Open split panes (left/right), drag divider rapidly — prompt should stay clean
- [ ] Open split panes (top/bottom), drag divider rapidly — prompt should stay clean
- [ ] Verify content reflows smoothly during drag (not just on release)
- [ ] Verify prompt redraws correctly after releasing the divider
- [ ] Close a tab during split drag — should recover gracefully without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)