### PR TITLE
fix(shell): respect user's default shell instead of hardcoding zsh

### DIFF
--- a/assets/macos/Kaku.app/Contents/Resources/kaku.lua
+++ b/assets/macos/Kaku.app/Contents/Resources/kaku.lua
@@ -291,7 +291,12 @@ config.colors = {
 }
 
 -- ===== Shell =====
-config.default_prog = { '/bin/zsh', '-l' }
+local user_shell = os.getenv('SHELL')
+if user_shell and #user_shell > 0 then
+  config.default_prog = { user_shell, '-l' }
+else
+  config.default_prog = { '/bin/zsh', '-l' }
+end
 
 -- ===== macOS Specific =====
 -- Keep Left Option as Meta so Alt-based Vim/Neovim keybindings work reliably.

--- a/assets/shell-integration/first_run.sh
+++ b/assets/shell-integration/first_run.sh
@@ -217,5 +217,19 @@ echo -e "\n\033[1;32m❤️ Kaku environment is ready! Enjoy coding.\033[0m"
 # Persist explicitly here so successful first-run/upgrade paths are recorded.
 persist_config_version
 
-# Replace current process with zsh to enter the shell
-exec /bin/zsh -l
+# Replace current process with the configured/default login shell:
+# 1) ~/.config/kaku/kaku.lua -> config.default_prog
+# 2) $SHELL
+# 3) /bin/zsh (fallback)
+KAKU_LUA_DEST="$HOME/.config/kaku/kaku.lua"
+CONFIGURED_SHELL=""
+if [[ -f "$KAKU_LUA_DEST" ]]; then
+	CONFIGURED_SHELL="$(sed -nE "s/^[[:space:]]*config\.default_prog[[:space:]]*=[[:space:]]*\{[[:space:]]*['\"]([^'\"]+)['\"].*$/\1/p" "$KAKU_LUA_DEST" | tail -n 1)"
+fi
+
+TARGET_SHELL="${CONFIGURED_SHELL:-${SHELL:-/bin/zsh}}"
+if [[ ! -x "$TARGET_SHELL" ]]; then
+	TARGET_SHELL="/bin/zsh"
+fi
+
+exec "$TARGET_SHELL" -l


### PR DESCRIPTION
## Summary
- **kaku.lua**: Use `$SHELL` environment variable for `config.default_prog`, falling back to `/bin/zsh` when unset
- **first_run.sh**: After first-run setup, launch the shell by priority: user config (`config.default_prog`) > `$SHELL` > `/bin/zsh`, with executable validation

## Test plan
- [ ] Verify fish/bash users get their own shell instead of zsh
- [ ] Verify zsh users are unaffected
- [ ] Verify fallback to `/bin/zsh` when `$SHELL` is unset
- [ ] Verify first_run.sh respects `config.default_prog` in user's `kaku.lua`

🤖 Generated with [Claude Code](https://claude.com/claude-code)