### PR TITLE
fix(macos): set Arrow cursor in title/padding area above terminal content

### DIFF
--- a/kaku-gui/src/termwindow/mouseevent.rs
+++ b/kaku-gui/src/termwindow/mouseevent.rs
@@ -313,6 +313,13 @@ impl super::TermWindow {
             }
             context.request_drag_move();
             return;
+        } else if event.coords.y < terminal_origin_y
+            && self.current_mouse_capture.is_none()
+        {
+            // Mouse is above terminal content (title/padding area) with no UI
+            // item hit and no active capture. Explicitly set Arrow cursor so
+            // macOS does not fall back to the NSTextInputClient default IBeam.
+            context.set_cursor(Some(MouseCursor::Arrow));
         } else if matches!(
             self.current_mouse_capture,
             None | Some(MouseCapture::TerminalPane(_))


### PR DESCRIPTION
## Summary

- **Bug**: When using `INTEGRATED_BUTTONS | RESIZE` window decorations with the tab bar hidden, the mouse cursor stays as IBeam (text input beam) everywhere — even in the title/padding area above terminal content. It never changes to the standard Arrow cursor.
- **Root cause**: In `mouse_event_impl()`, when Move events land in the padding area above `terminal_origin_y` and no UI item is hit, no dispatch branch matches — so `set_cursor()` is never called. On macOS, the `NSTextInputClient` protocol causes the default cursor to fall back to IBeam.
- **Fix**: Add a 5-line branch between the drag-start branch and the terminal-content branch that explicitly sets `MouseCursor::Arrow` when the pointer is above `terminal_origin_y`, no UI item was hit, and no mouse capture is active (`current_mouse_capture.is_none()`).

## Details

The new branch is inserted in the `if/else if` chain at the end of `mouse_event_impl()`:

```rust
} else if event.coords.y < terminal_origin_y
    && self.current_mouse_capture.is_none()
{
    // Mouse is above terminal content (title/padding area) with no UI
    // item hit and no active capture. Explicitly set Arrow cursor so
    // macOS does not fall back to the NSTextInputClient default IBeam.
    context.set_cursor(Some(MouseCursor::Arrow));
} else if matches!(
```

The `current_mouse_capture.is_none()` guard ensures this branch does not interfere with active drag operations (e.g., split resizing or scroll thumb dragging that crosses into the padding area).

## Test plan

- [ ] Build on macOS: `cargo build` succeeds
- [ ] Launch Kaku with `INTEGRATED_BUTTONS | RESIZE` decorations and tab bar hidden
- [ ] Move mouse into the padding area above terminal content → cursor should be Arrow (not IBeam)
- [ ] Move mouse into terminal content area → cursor should be Text (unchanged behavior)
- [ ] Drag window by clicking in padding area → drag still works (unchanged behavior)
- [ ] Split pane drag that crosses into padding area → drag still works (capture guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)