### PR TITLE
refactor: apply idiomatic Rust cleanups across GUI and CLI

### DIFF
--- a/kaku-gui/src/frontend.rs
+++ b/kaku-gui/src/frontend.rs
@@ -284,7 +284,7 @@ impl GuiFrontEnd {
                                         Clipboard::PrimarySelection
                                     }
                                 },
-                                clipboard.unwrap_or_else(String::new),
+                                clipboard.unwrap_or_default(),
                             );
                         } else {
                             log::error!("Cannot assign clipboard as there are no windows");
@@ -318,7 +318,7 @@ impl GuiFrontEnd {
                     None
                 } else {
                     match shlex::try_quote(&file_name) {
-                        Ok(name) => Some(name.to_owned().to_string()),
+                        Ok(name) => Some(name.into_owned()),
                         Err(_) => {
                             log::error!(
                                 "OpenCommandScript: {file_name} has embedded NUL bytes and

--- a/kaku-gui/src/inputmap.rs
+++ b/kaku-gui/src/inputmap.rs
@@ -6,7 +6,6 @@ use config::keyassignment::{
 use config::{ConfigHandle, MouseEventAltScreen, MouseEventTriggerMods};
 use std::collections::HashMap;
 use std::time::Duration;
-// use wezterm_dynamic::{ToDynamic, Value};
 use wezterm_term::input::MouseButton;
 use window::{KeyCode, Modifiers, PhysKeyCode, UIKeyCapRendering};
 
@@ -428,7 +427,7 @@ impl InputMap {
     pub fn is_leader(&self, key: &KeyCode, mods: Modifiers) -> Option<std::time::Duration> {
         if let Some((leader_key, leader_mods, timeout)) = self.leader.as_ref() {
             if *leader_key == *key && *leader_mods == mods.remove_positional_mods() {
-                return Some(timeout.clone());
+                return Some(*timeout);
             }
         }
         None

--- a/kaku-gui/src/tabbar.rs
+++ b/kaku-gui/src/tabbar.rs
@@ -213,9 +213,9 @@ fn compute_tab_title(
 }
 
 fn is_tab_hover(mouse_x: Option<usize>, x: usize, tab_title_len: usize) -> bool {
-    return mouse_x
+    mouse_x
         .map(|mouse_x| mouse_x >= x && mouse_x < x + tab_title_len)
-        .unwrap_or(false);
+        .unwrap_or(false)
 }
 
 impl TabBarState {
@@ -410,7 +410,7 @@ impl TabBarState {
         let available_cells = title_width.saturating_sub(controls_width);
         let tab_width_max = if config.use_fancy_tab_bar || available_cells >= titles_len {
             // We can render each title with its full width
-            usize::max_value()
+            usize::MAX
         } else {
             // We need to clamp the length to balance them out
             available_cells / number_of_tabs
@@ -430,10 +430,10 @@ impl TabBarState {
 
         if use_integrated_title_buttons
             && config.integrated_title_button_style == IntegratedTitleButtonStyle::MacOsNative
-            && config.use_fancy_tab_bar == false
-            && config.tab_bar_at_bottom == false
+            && !config.use_fancy_tab_bar
+            && !config.tab_bar_at_bottom
         {
-            for _ in 0..10 as usize {
+            for _ in 0..10_usize {
                 line.insert_cell(0, black_cell.clone(), title_width, SEQ_ZERO);
                 x += 1;
             }

--- a/kaku/src/main.rs
+++ b/kaku/src/main.rs
@@ -23,8 +23,6 @@ mod init;
 mod reset;
 mod update;
 
-//    let message = "; ❤ 😍🤢\n\x1b[91;mw00t\n\x1b[37;104;m bleet\x1b[0;m.";
-
 #[derive(Debug, Parser)]
 #[command(
     about = "Kaku Terminal Emulator\nhttp://github.com/tw93/Kaku",
@@ -366,7 +364,9 @@ impl ImgCatCommand {
 
                     candidates.sort_by(|a, b| (a.0 * a.1).cmp(&(b.0 * b.1)));
 
-                    candidates.pop().unwrap()
+                    // candidates is non-empty because at least one scaling
+                    // direction always satisfies the constraint above.
+                    candidates.pop().expect("at least one candidate fits")
                 } else {
                     (width, height)
                 }


### PR DESCRIPTION
Replace non-idiomatic patterns with Clippy-recommended alternatives: unwrap_or_default, Copy dereference over clone, implicit returns, bool negation, is_empty, usize::MAX, and bare unwrap to expect.