### PR TITLE
feat: double-click title/tab bar to zoom window on macOS

### DIFF
--- a/crates/wezterm-input-types/src/lib.rs
+++ b/crates/wezterm-input-types/src/lib.rs
@@ -1278,6 +1278,8 @@ pub struct MouseEvent {
     pub screen_coords: crate::ScreenPoint,
     pub mouse_buttons: MouseButtons,
     pub modifiers: Modifiers,
+    /// OS-reported click count (1=single, 2=double, etc.)
+    pub click_count: u32,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

- Double-clicking on the title/padding area or empty tab bar area now toggles window zoom (maximize/restore) on macOS
- Fixes window dragging to use synchronous `performWindowDragWithEvent:` instead of async path, ensuring reliable double-click detection
- Adds `click_count` field to `MouseEvent` struct, populated from `NSEvent.clickCount`

## Root Cause

`mouseDownCanMoveWindow` returned `YES`, causing macOS to intercept all `mouseDown` events for native window dragging. The view's `mouseDown:` was never called, so any app-level click detection was impossible.

## Approach (inspired by Ghostty)

| Click | Behavior |
|-------|----------|
| Single click on title/tab bar | `performWindowDragWithEvent:` — start window drag |
| Double click on title/tab bar | `NSWindow zoom:` — toggle maximize/restore |

Key changes:
- `mouseDownCanMoveWindow` → `NO` so `mouseDown:` is always delivered
- `request_drag_move()` sets a thread-local flag instead of async scheduling
- `mouse_down()` checks the flag and calls `performWindowDragWithEvent:` synchronously
- Removed dead code (`WindowInner::request_drag_move`)

## Test Plan

- [x] Build and run on Apple Silicon (M5 MacBook Pro, macOS)
- [x] Single click + drag on title/padding area moves window
- [x] Double-click on title/padding area toggles zoom
- [x] Double-click on empty tab bar area toggles zoom
- [x] Terminal area mouse events (click, selection, scroll) unaffected
- [x] Window traffic-light buttons (close/minimize/maximize) work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)