### PR TITLE
feat(macos): support drag-and-drop folders to Dock icon

### DIFF
--- a/assets/macos/Kaku.app/Contents/Info.plist
+++ b/assets/macos/Kaku.app/Contents/Info.plist
@@ -85,11 +85,17 @@
 			<key>CFBundleTypeName</key>
 			<string>Folders</string>
 			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
+			<string>Viewer</string>
 			<key>CFBundleTypeOSTypes</key>
 			<array>
 				<string>fold</string>
 			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.folder</string>
+			</array>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
 		</dict>
 		<dict>
 			<key>CFBundleTypeRole</key>


### PR DESCRIPTION
## Summary                                                                                                          

  - Add `public.folder` UTI support to enable drag-and-drop folders from Finder/QSpace to Dock icon
  - Kaku will open a new terminal window with the dropped folder as the working directory

  ## Changes

  - Added `LSItemContentTypes` with `public.folder` to `CFBundleDocumentTypes` in Info.plist
  - Set `LSHandlerRank` to `Alternate` (Kaku can open folders but won't become the default handler)
  - Changed `CFBundleTypeRole` from `Editor` to `Viewer` for folders

  ## Test plan

  - [x] Build the app with `make app`
  - [x] Drag a folder from Finder to Kaku's Dock icon
  - [x] Drag a folder from QSpace (or other file managers) to Kaku's Dock icon
