### PR TITLE
fix: support image clipboard paste in macOS TUI chat

### DIFF
--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -44,6 +44,12 @@ pub enum Clipboard {
     PrimarySelection,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClipboardData {
+    Text(String),
+    Files(Vec<PathBuf>),
+}
+
 impl Default for Clipboard {
     fn default() -> Self {
         Self::Clipboard
@@ -315,6 +321,8 @@ pub trait WindowOps {
 
     /// Initiate textual transfer from the clipboard
     fn get_clipboard(&self, clipboard: Clipboard) -> Future<String>;
+
+    fn get_clipboard_data(&self, clipboard: Clipboard) -> Future<ClipboardData>;
 
     /// Set some text in the clipboard
     fn set_clipboard(&self, clipboard: Clipboard, text: String);

--- a/window/src/os/macos/clipboard.rs
+++ b/window/src/os/macos/clipboard.rs
@@ -1,7 +1,18 @@
 use crate::macos::{nsstring, nsstring_to_str};
+use crate::ClipboardData;
 use cocoa::appkit::{NSFilenamesPboardType, NSPasteboard, NSStringPboardType};
 use cocoa::base::*;
 use cocoa::foundation::NSArray;
+use objc::*;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const PNG_PASTEBOARD_TYPE: &str = "public.png";
+const TIFF_PASTEBOARD_TYPE: &str = "public.tiff";
+const MAX_CLIPBOARD_IMAGE_BYTES: usize = 32 * 1024 * 1024;
+const CLIPBOARD_IMAGE_DIR: &str = "clipboard-images";
 
 pub struct Clipboard {
     pasteboard: id,
@@ -16,26 +27,109 @@ impl Clipboard {
         Clipboard { pasteboard }
     }
 
-    pub fn read(&self) -> anyhow::Result<String> {
+    fn read_image_data(&self) -> anyhow::Result<Option<(Vec<u8>, &'static str)>> {
+        unsafe {
+            for (uti, extension) in [(PNG_PASTEBOARD_TYPE, "png"), (TIFF_PASTEBOARD_TYPE, "tiff")] {
+                let data: id = msg_send![self.pasteboard, dataForType:*nsstring(uti)];
+                if data.is_null() {
+                    continue;
+                }
+
+                let len: usize = msg_send![data, length];
+                if len == 0 {
+                    continue;
+                }
+                anyhow::ensure!(
+                    len <= MAX_CLIPBOARD_IMAGE_BYTES,
+                    "clipboard image exceeds {} bytes",
+                    MAX_CLIPBOARD_IMAGE_BYTES
+                );
+
+                let bytes: *const u8 = msg_send![data, bytes];
+                anyhow::ensure!(!bytes.is_null(), "clipboard image bytes returned null");
+
+                let data = std::slice::from_raw_parts(bytes, len).to_vec();
+                return Ok(Some((data, extension)));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn write_image_to_runtime_dir(
+        &self,
+        image_data: &[u8],
+        extension: &str,
+    ) -> anyhow::Result<PathBuf> {
+        let dir = config::RUNTIME_DIR.join(CLIPBOARD_IMAGE_DIR);
+        config::create_user_owned_dirs(&dir)?;
+
+        let pid = std::process::id();
+        for attempt in 0..64u32 {
+            let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+            let file_name = format!("clipboard-image-{pid}-{now}-{attempt}.{extension}");
+            let path = dir.join(file_name);
+
+            let mut options = std::fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            options.mode(0o600);
+
+            match options.open(&path) {
+                Ok(mut file) => {
+                    use std::io::Write;
+                    file.write_all(image_data)?;
+                    return Ok(path);
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(err) => return Err(err.into()),
+            }
+        }
+
+        anyhow::bail!("failed to allocate unique clipboard image path")
+    }
+
+    pub fn read_data(&self) -> anyhow::Result<ClipboardData> {
         unsafe {
             let plist = self.pasteboard.propertyListForType(NSFilenamesPboardType);
             if !plist.is_null() {
                 let mut filenames = vec![];
                 for i in 0..plist.count() {
-                    filenames.push(
-                        shlex::try_quote(nsstring_to_str(plist.objectAtIndex(i)))
-                            .unwrap_or_else(|_| "".into()),
-                    );
+                    filenames.push(PathBuf::from(nsstring_to_str(plist.objectAtIndex(i))));
                 }
-                return Ok(filenames.join(" "));
+                return Ok(ClipboardData::Files(filenames));
             }
             let s = self.pasteboard.stringForType(NSStringPboardType);
             if !s.is_null() {
                 let str = nsstring_to_str(s);
-                return Ok(str.to_string());
+                return Ok(ClipboardData::Text(str.to_string()));
             }
         }
+
+        if let Some((image_data, extension)) = self.read_image_data()? {
+            let path = self.write_image_to_runtime_dir(&image_data, extension)?;
+            return Ok(ClipboardData::Files(vec![path]));
+        }
+
         anyhow::bail!("pasteboard read returned empty");
+    }
+
+    pub fn read(&self) -> anyhow::Result<String> {
+        match self.read_data()? {
+            ClipboardData::Text(text) => Ok(text),
+            ClipboardData::Files(paths) => {
+                let quoted = paths
+                    .iter()
+                    .map(|path| {
+                        shlex::try_quote(path.to_string_lossy().as_ref())
+                            .unwrap_or_else(|_| "".into())
+                            .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                Ok(quoted)
+            }
+        }
     }
 
     pub fn write(&mut self, data: String) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- add structured clipboard payload support in the window API (`ClipboardData`) so paste flows can distinguish text vs file paths
- implement macOS clipboard image handling for `public.png`/`public.tiff`, materialize clipboard image bytes into a private runtime directory, then pass file paths through existing paste flow
- update TUI paste handling to consume structured clipboard data, keep dropped-file quoting behavior, and log paste/read failures instead of silently ignoring them

## Verification
- `cargo +nightly fmt -p kaku -p kaku-gui -p mux -p wezterm-term -p termwiz -p config -p wezterm-font`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0 -Ccodegen-units=1' make check` *(stopped by SIGKILL in local environment while checking `kaku` build script)*
- `CARGO_BUILD_JOBS=1 cargo check -p window`
- `CARGO_BUILD_JOBS=1 cargo test -p window --no-run`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0 -Ccodegen-units=1' cargo check -p kaku-gui --bin kaku-gui`