### PR TITLE
fix: correct split pane labels and descriptions

### DIFF
--- a/kaku-gui/src/commands.rs
+++ b/kaku-gui/src/commands.rs
@@ -1489,9 +1489,9 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             domain: SpawnTabDomain::CurrentPaneDomain,
             ..
         }) => CommandDef {
-            brief: label_string(action, "Split Vertically (Top/Bottom)".to_string()).into(),
+            brief: label_string(action, "Split Vertically (Left/Right)".to_string()).into(),
             doc: "Split the current pane vertically into two panes, by spawning \
-            the default program into the bottom half"
+            the default program into the right half"
                 .into(),
             keys: vec![(
                 Modifiers::CTRL
@@ -1507,9 +1507,9 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             domain: SpawnTabDomain::CurrentPaneDomain,
             ..
         }) => CommandDef {
-            brief: label_string(action, "Split Horizontally (Left/Right)".to_string()).into(),
+            brief: label_string(action, "Split Horizontally (Top/Bottom)".to_string()).into(),
             doc: "Split the current pane horizontally into two panes, by spawning \
-            the default program into the right hand side"
+            the default program into the bottom half"
                 .into(),
             keys: vec![(
                 Modifiers::CTRL
@@ -1522,9 +1522,9 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: Some("cod_split_horizontal"),
         },
         SplitHorizontal(_) => CommandDef {
-            brief: label_string(action, "Split Horizontally (Left/Right)".to_string()).into(),
+            brief: label_string(action, "Split Horizontally (Top/Bottom)".to_string()).into(),
             doc: "Split the current pane horizontally into two panes, by spawning \
-            the default program into the right hand side"
+            the default program into the bottom half"
                 .into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
@@ -1532,9 +1532,9 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: Some("cod_split_horizontal"),
         },
         SplitVertical(_) => CommandDef {
-            brief: label_string(action, "Split Vertically (Top/Bottom)".to_string()).into(),
-            doc: "Split the current pane veritically into two panes, by spawning \
-            the default program into the bottom"
+            brief: label_string(action, "Split Vertically (Left/Right)".to_string()).into(),
+            doc: "Split the current pane vertically into two panes, by spawning \
+            the default program into the right half"
                 .into(),
             keys: vec![],
             args: &[ArgType::ActivePane],


### PR DESCRIPTION
## Summary
- Fixed swapped labels: "Split Vertically" now correctly shows "(Left/Right)" instead of "(Top/Bottom)"
- Fixed swapped labels: "Split Horizontally" now correctly shows "(Top/Bottom)" instead of "(Left/Right)"
- Updated docstrings to match the actual behavior (vertical split → right half, horizontal split → bottom half)
- Also fixed typo: "veritically" → "vertical"

## Related Issue
Fixes #46 - Split Vertically and Split Horizontally labels are swapped