### PR TITLE
fix(mux,macOS): respect split gutters for pane nav and handle Cmd+non-menu keys

### DIFF
--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -1620,45 +1620,33 @@ impl TabInner {
             )
         }
 
+        let col_gutter = split_col_gutter();
+        let row_gutter = split_row_gutter();
+
         for pane in &panes {
-            let score = match direction {
+            let is_candidate = match direction {
                 PaneDirection::Right => {
-                    if pane.left == active.left + active.width + 1
+                    pane.left == active.left + active.width + col_gutter
                         && edge_intersects(active.top, active.height, pane.top, pane.height)
-                    {
-                        1 + recency.score(pane.index)
-                    } else {
-                        0
-                    }
                 }
                 PaneDirection::Left => {
-                    if pane.left + pane.width + 1 == active.left
+                    pane.left + pane.width + col_gutter == active.left
                         && edge_intersects(active.top, active.height, pane.top, pane.height)
-                    {
-                        1 + recency.score(pane.index)
-                    } else {
-                        0
-                    }
                 }
                 PaneDirection::Up => {
-                    if pane.top + pane.height + 1 == active.top
+                    pane.top + pane.height + row_gutter == active.top
                         && edge_intersects(active.left, active.width, pane.left, pane.width)
-                    {
-                        1 + recency.score(pane.index)
-                    } else {
-                        0
-                    }
                 }
                 PaneDirection::Down => {
-                    if active.top + active.height + 1 == pane.top
+                    active.top + active.height + row_gutter == pane.top
                         && edge_intersects(active.left, active.width, pane.left, pane.width)
-                    {
-                        1 + recency.score(pane.index)
-                    } else {
-                        0
-                    }
                 }
                 PaneDirection::Next | PaneDirection::Prev => unreachable!(),
+            };
+            let score = if is_candidate {
+                1 + recency.score(pane.index)
+            } else {
+                0
             };
 
             if score > 0 {


### PR DESCRIPTION
## Summary
This PR fixes two input/navigation issues:

1. Pane directional navigation in `mux` now respects configured split gutters instead of assuming a hardcoded `1` cell gap.
2. macOS `performKeyEquivalent` now intercepts `Cmd` + non-menu virtual keys (arrows, Home/End/PageUp/PageDown/Delete/Help, F1-F20) so they are forwarded as app key events instead of being consumed by the system.

## Problem
- Pane focus movement could fail when custom split gutter sizes were configured, because adjacency checks used fixed offsets.
- On macOS, `Cmd`-modified special keys could be swallowed by Cocoa (or trigger beeps), preventing key bindings from receiving them.

## Changes
- `mux/src/tab.rs`
  - Replaced hardcoded pane adjacency offsets with `split_col_gutter()` and `split_row_gutter()`.
  - Kept recency-based scoring logic, but refactored candidate detection for clarity.
- `window/src/os/macos/window.rs`
  - Added `is_non_menu_virtual_key(vkey)` helper for arrows/navigation/function keys.
  - In `performKeyEquivalent`, detect `Cmd` + non-menu virtual keys and synthesize key events via `key_common(...)`.
  - Preserved existing special shortcut handling (`Cmd+.`, `Ctrl+Esc`, `Ctrl+Tab`, `Shift+Tab`).

## Impact
- Pane navigation behaves correctly with non-default gutter configuration.
- macOS users can reliably bind/use `Cmd` + arrows/navigation/function keys in-app.

## Testing
- Manual:
  - Configure non-default pane gutters and verify Left/Right/Up/Down pane movement.
  - On macOS, verify `Cmd` + Arrow/Home/End/PageUp/PageDown/F-keys reach app bindings and no system beep occurs.
