### PR TITLE
feat: add TogglePaneSplitDirection to toggle split H↔V

### DIFF
--- a/assets/macos/Kaku.app/Contents/Resources/kaku.lua
+++ b/assets/macos/Kaku.app/Contents/Resources/kaku.lua
@@ -676,6 +676,13 @@ config.keys = {
     action = wezterm.action.TogglePaneZoomState,
   },
 
+  -- Cmd+Shift+S: Toggle split direction (horizontal <-> vertical)
+  {
+    key = 'S',
+    mods = 'CMD|SHIFT',
+    action = wezterm.action.TogglePaneSplitDirection,
+  },
+
   -- Cmd+Ctrl+Arrows: Resize panes
   {
     key = 'LeftArrow',

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -633,6 +633,7 @@ pub enum KeyAssignment {
 
     CopyMode(CopyModeAssignment),
     RotatePanes(RotationDirection),
+    TogglePaneSplitDirection,
     SplitPane(SplitPane),
     PaneSelect(PaneSelectArguments),
     CharSelect(CharSelectArguments),

--- a/kaku-gui/src/commands.rs
+++ b/kaku-gui/src/commands.rs
@@ -2018,6 +2018,14 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
                 RotationDirection::CounterClockwise => "md_rotate_left",
             }),
         },
+        TogglePaneSplitDirection => CommandDef {
+            brief: "Toggle Split Direction".into(),
+            doc: "Toggle the split direction between horizontal and vertical".into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["Window"],
+            icon: Some("cod_split_vertical"),
+        },
         SplitPane(split) => {
             let direction = split.direction;
             CommandDef {
@@ -2136,6 +2144,7 @@ fn compute_default_actions() -> Vec<KeyAssignment> {
         }),
         RotatePanes(RotationDirection::Clockwise),
         RotatePanes(RotationDirection::CounterClockwise),
+        TogglePaneSplitDirection,
         ActivateTab(0),
         ActivateTab(1),
         ActivateTab(2),

--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -3345,6 +3345,14 @@ impl TermWindow {
                     RotationDirection::CounterClockwise => tab.rotate_counter_clockwise(),
                 }
             }
+            TogglePaneSplitDirection => {
+                let mux = Mux::get();
+                let tab = match mux.get_active_tab_for_window(self.mux_window_id) {
+                    Some(tab) => tab,
+                    None => return Ok(PerformAssignmentResult::Handled),
+                };
+                tab.toggle_pane_split_direction();
+            }
             SplitPane(split) => {
                 log::trace!("SplitPane {:?}", split);
                 self.spawn_command(


### PR DESCRIPTION
## Summary

Add `TogglePaneSplitDirection` action that toggles the split direction of the active pane's parent split node between Horizontal (left|right) and Vertical (top|bottom).

- **Shortcut**: `Cmd+Shift+S`
- Similar to iTerm2's "Swap Split Direction", but neither iTerm2, Ghostty, nor upstream WezTerm have this as a single-key toggle

## How it works

1. Find the active pane in the split tree
2. Move up to its parent split node
3. Flip `H ↔ V` and recalculate child dimensions (50/50 split)
4. Cascade sizes down to nested children via `cascade_size_from_cursor`

## Edge cases handled

| Case | Behavior |
|------|----------|
| Single pane (no split) | No-op, returns immediately |
| Pane is zoomed | No-op, returns immediately |
| Insufficient space for new direction | No-op, silently skipped (avoids spurious resize) |
| Nested splits (3+ panes) | Only flips the active pane's immediate parent split |

## Files changed (5 files, +127 lines)

- `config/src/keyassignment.rs` — enum variant
- `mux/src/tab.rs` — core toggle logic + minimum-size guard
- `kaku-gui/src/termwindow/mod.rs` — action dispatch
- `kaku-gui/src/commands.rs` — command definition
- `assets/.../kaku.lua` — keybinding (`Cmd+Shift+S`)

## Test plan

Tested manually + automated AppleScript on macOS:

- [x] Single pane → `Cmd+Shift+S` → no change, no crash
- [x] H-split → toggle → becomes V-split → toggle → back to H-split
- [x] V-split → toggle → becomes H-split
- [x] Nested 3-pane → toggle → only active pane's parent flips
- [x] Zoomed pane → toggle → no change; unzoom → layout preserved