### PR TITLE
Add kaku://open-tab?tty= URL handler to focus pane by tty

### DIFF
--- a/assets/macos/Kaku.app/Contents/Info.plist
+++ b/assets/macos/Kaku.app/Contents/Info.plist
@@ -22,6 +22,17 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>0.3.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>fun.tw93.kaku</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kaku</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleIconFile</key>
 	<string>terminal.icns</string>
 	<key>LSApplicationCategoryType</key>

--- a/window/src/connection.rs
+++ b/window/src/connection.rs
@@ -25,6 +25,8 @@ pub enum ApplicationEvent {
     OpenCommandScript(String),
     /// The system wants to open a command in a new tab when possible
     OpenCommandScriptInTab(String),
+    /// The system requests focusing the tab/pane that owns this tty.
+    ActivatePaneForTty(String),
     PerformKeyAssignment(KeyAssignment),
 }
 


### PR DESCRIPTION
### Summary
This PR adds a macOS URL-scheme handler for:

- `kaku://open-tab?tty=<tty>`

When Kaku receives this URL, it:

1. Parses the tty query value.
2. Finds the pane matching that TTY.
3. Activates the containing tab/pane.
4. Focuses the corresponding GUI window.

### What changed
- Added new app event to carry TTY activation requests:
  - `ActivatePaneForTty(String)`
- Added macOS app delegate URL handler:
  - `application:openURLs:`
- Added URL parser logic for `kaku://open-tab?tty=...`
- Added pending queue support for TTY activations during startup
- Added frontend logic to resolve pane by TTY and focus it
  - Handles both `/dev/ttysXXX` and `ttysXXX` forms
- Registered URL scheme in app Info.plist:
  - `CFBundleURLSchemes = ["kaku"]`

### Behavior notes
- `kaku://open-tab?tty=` (empty/whitespace tty) is ignored.
- Unsupported/invalid URLs are ignored with warning logs.

### Validation
 
1. Get tty of some tab or panel
```bash
❯ tty                                                                                                                                                                                                                
/dev/ttys046
```
2. Run:
```
open "kaku://open-tab?tty=/dev/ttys046"
```
Confirm matching pane/tab/window is focused

