### PR TITLE
feat: support branch switch

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1769,6 +1769,10 @@ fn default_initial_cols() -> u16 {
 
 pub fn default_hyperlink_rules() -> Vec<hyperlink::Rule> {
     vec![
+        // Treat prompt git-branch segments as clickable.
+        // Examples: ` main`, ` main`, ` main`.
+        // The full segment (icon + branch) is clickable so clicking the icon works too.
+        hyperlink::Rule::new(r"(?:||)\s*[^\s]+", "kaku://switch-git-branch").unwrap(),
         // First handle URLs wrapped with punctuation (i.e. brackets)
         // e.g. [http://foo] (http://foo) <http://foo>
         hyperlink::Rule::with_highlight(r"\((\w+://\S+)\)", "$1", 1).unwrap(),

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -639,6 +639,8 @@ pub enum KeyAssignment {
     CharSelect(CharSelectArguments),
 
     ResetTerminal,
+    SwitchGitBranch,
+    SwitchToGitBranch(String),
     OpenUri(String),
     ActivateCommandPalette,
     ActivateWindow(usize),

--- a/kaku-gui/src/commands.rs
+++ b/kaku-gui/src/commands.rs
@@ -2049,6 +2049,22 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             menubar: &["Shell"],
             icon: None,
         },
+        SwitchGitBranch => CommandDef {
+            brief: "Switch Git Branch".into(),
+            doc: "Show a branch picker for the active pane and switch branches".into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["Shell"],
+            icon: Some("oct_git_branch"),
+        },
+        SwitchToGitBranch(branch) => CommandDef {
+            brief: format!("Switch Git branch to `{branch}`").into(),
+            doc: format!("Switch the active pane to git branch `{branch}`").into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &[],
+            icon: Some("oct_git_branch"),
+        },
         ActivateCommandPalette => CommandDef {
             brief: "Activate Command Palette".into(),
             doc: "Shows the command palette modal".into(),
@@ -2085,6 +2101,7 @@ fn compute_default_actions() -> Vec<KeyAssignment> {
         CloseCurrentPane { confirm: true },
         DetachDomain(SpawnTabDomain::CurrentPaneDomain),
         ResetTerminal,
+        SwitchGitBranch,
         // ----------------- Edit
         #[cfg(not(target_os = "macos"))]
         PasteFrom(ClipboardPasteSource::PrimarySelection),


### PR DESCRIPTION
This PR add branch switch support:
1. Support opening the branch list modal by clicking the current branch name, and switching branches via mouse or keyboard.
2. Support filtering the branch list by keyword.
The UI screenshot:
<img width="2280" height="1376" alt="image" src="https://github.com/user-attachments/assets/47415b77-5232-4ad0-a3ad-5d0540363613" />
