### PR TITLE
Fix: missing space between prompt and user input

### DIFF
--- a/assets/vendor/starship.toml
+++ b/assets/vendor/starship.toml
@@ -41,3 +41,6 @@ disabled = true
 
 [terraform]
 disabled = true
+
+[rust]
+format = "via [$symbol($version)]($style)"


### PR DESCRIPTION
## Fix: missing space between prompt and user input

### Problem

The Starship prompt character module had empty `success_symbol` and `error_symbol`, causing user input to visually concatenate with the version number (e.g. `v1.2.5ls` instead of `v1.2.5 ls`).

### Root Cause

- `[character]` symbols were set to `""` with `format = "$symbol"`, producing no trailing space
- The bundled Starship's Bun module does not include a trailing space in its default format

### Fix

- Set `success_symbol` and `error_symbol` to `" "` so the prompt always ends with a single space
- Override `[rust]` module format to remove its built-in trailing space in the version group, preventing double-space in Rust project directories

<img width="1704" height="970" alt="image" src="https://github.com/user-attachments/assets/762b03da-c6cc-42f7-83e2-58f90ca4f990" />

### Changes

```diff
 [character]
-success_symbol = ""
-error_symbol = ""
+success_symbol = " "
+error_symbol = " "

+[rust]
+format = "via [$symbol($version)]($style)"
