### PR TITLE
fix: resolve hidden prompt spacing bug introduced by previous merge

### DIFF
--- a/assets/vendor/starship.toml
+++ b/assets/vendor/starship.toml
@@ -4,14 +4,34 @@ add_newline = false
 command_timeout = 10000
 
 [directory]
-truncate_to_repo=true
-truncation_length=2
+truncate_to_repo = true
+truncation_length = 2
+# Remove trailing space (default has one outside styled group).
+# The [character] module provides the sole trailing space.
+format = "[$path]($style)[$read_only]($read_only_style)"
 
 [character]
 success_symbol = " "
 error_symbol = " "
 format = "$symbol"
 
+# Modules whose default format places trailing space OUTSIDE styled group:
+# override to remove it, preventing double-space with character.
+[git_branch]
+format = "on [$symbol$branch(:$remote_branch)]($style)"
+
+[git_status]
+format = "([\\[$all_status$ahead_behind\\]]($style))"
+
+[package]
+format = "is [$symbol$version]($style)"
+
+[cmd_duration]
+format = "took [$duration]($style)"
+
+# Modules whose default format places trailing space INSIDE styled group
+# (e.g. bun, rust): override to also remove it, so only [character] provides
+# the trailing space.
 [rust]
 format = "via [$symbol($version)]($style)"
 


### PR DESCRIPTION
### Problem Discovery
After the previous merge that configured `starship.toml` with empty character symbols (`success_symbol/error_symbol = ""`), the shell prompt had no trailing space, causing user input to concatenate directly with the version number (e.g. `v1.2.5ls` instead of `v1.2.5 ls`).
### Root Cause Analysis
The Kaku terminal has a quirk in how it handles trailing whitespace in the prompt:
1. **Empty `[character]` module**: `format = "$symbol"` with empty symbols produced zero trailing characters — no separator between prompt and user input.
2. **Inconsistent trailing space placement across Starship modules**:
   - Language modules (`bun`, `rust`) place their trailing space **inside** ANSI color sequences (styled space), which gets trimmed by the Kaku terminal.
   - Infrastructure modules (`directory`, `git_branch`, `git_status`) place their trailing space **outside** ANSI sequences (unstyled space), which the terminal preserves.
3. **Naive fix creates double-spacing**: Simply adding a space to the character symbol fixes `bun`/`rust` (the unstyled character space anchors the trimmed styled space), but creates double-spacing for `directory`/`git` modules (their preserved unstyled space + character space = two visible spaces).
### Fix
| Strategy                          | Detail                                                                                                                                   |
| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
| **Character space**               | Set `success_symbol = " "` to serve as the sole prompt trailing separator                                                                |
| **Remove module trailing spaces** | Override `directory`, `git_branch`, `git_status`, `rust`, `package`, and `cmd_duration` formats to remove their built-in trailing spaces |
| **Keep bun default**              | Its styled trailing space gets trimmed by the terminal, so no conflict with the character space                                          |
### Verification
| Scenario                         | Before      | After      |
| -------------------------------- | ----------- | ---------- |
| `~` (Bun module)                 | ✅ 1 space | ✅ 1 space |
| Project directory (Rust + Git)   | ✅ 1 space  | ✅ 1 space |
| Plain directory (`Downloads`) | ❌ 2 space  | ✅ 1 space |



<img width="1704" height="970" alt="image" src="https://github.com/user-attachments/assets/b7dac073-6bbc-4fdc-910f-6755ab586d91" />
