### PR TITLE
fix: close tab instead of hide app when multiple windows exist

### DIFF
--- a/assets/macos/Kaku.app/Contents/Resources/kaku.lua
+++ b/assets/macos/Kaku.app/Contents/Resources/kaku.lua
@@ -467,7 +467,12 @@ config.keys = {
       elseif #tabs > 1 then
         win:perform_action(wezterm.action.CloseCurrentTab { confirm = false }, pane)
       else
-        win:perform_action(wezterm.action.HideApplication, pane)
+        local all_windows = wezterm.mux.all_windows()
+        if #all_windows > 1 then
+          win:perform_action(wezterm.action.CloseCurrentTab { confirm = false }, pane)
+        else
+          win:perform_action(wezterm.action.HideApplication, pane)
+        end
       end
     end),
   },


### PR DESCRIPTION
## Problem
When pressing Cmd+W to close the last tab in a window, the app always calls HideApplication — even when other windows are still open. This causes unexpected behavior where the entire app appears to hide while other windows remain.

## Solution
Check the total number of open windows before deciding the action:
- If multiple windows exist, close the current tab/window normally.
- If it's the only window, fall back to HideApplication (existing behavior).

## Changes
- kaku.lua: Added a window count check in the Cmd+W key handler to conditionally close the tab or hide the app.