### PR TITLE
fix(ssh): override TERM=kaku to xterm-256color for remote sessions

### DIFF
--- a/mux/src/ssh.rs
+++ b/mux/src/ssh.rs
@@ -265,6 +265,13 @@ impl RemoteSshDomain {
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
 
+        // Remote servers won't have the "kaku" terminfo entry, which causes
+        // garbled display over SSH.  Override to xterm-256color so the remote
+        // side can handle cursor movement, line wrapping, etc. correctly.
+        if env.get("TERM").map(|t| t.as_str()) == Some("kaku") {
+            env.insert("TERM".to_string(), "xterm-256color".to_string());
+        }
+
         // FIXME: this isn't useful without a way to talk to the remote mux.
         // One option is to forward the mux via unix domain, another is to
         // embed the mux protocol in an escape sequence and just use the


### PR DESCRIPTION
## Summary

When SSHing from Kaku into a remote server, `$TERM` is set to `kaku`, which causes garbled/misaligned display because remote servers don't have a `kaku` terminfo entry.

## Root Cause

`config.apply_cmd_defaults()` injects `TERM=kaku` into the `CommandBuilder`. When `RemoteSshDomain::build_command()` collects env vars from it, `TERM=kaku` ends up in the HashMap that gets sent to the remote server via two paths:

1. **`request_env()`** — SSH `setenv` request (if server has `AcceptEnv TERM`)
2. **Posix shell command line** — `env TERM=kaku ... $SHELL` (always overrides)

Although `request_pty()` correctly passes `"xterm-256color"` as the PTY terminal type, the env var overrides it on the remote side.

## Fix

Override `TERM` from `kaku` to `xterm-256color` in the env HashMap inside `build_command()`, before it is sent to the remote server. This is a single-point fix that covers both the `setenv` and Posix command-line paths, while preserving the `kaku` terminfo for local terminal sessions.

## Note

The existing zsh shell-integration SSH wrapper (`setup_zsh.sh:345`) only fixes the case where users manually type `ssh` in a zsh shell. It does not cover the built-in SSH Domain (`RemoteSshDomain`), non-zsh shells, or programmatic SSH invocations.