### PR TITLE
fix: fill transparent gap between tab bar and pane content

### DIFF
--- a/kaku-gui/src/termwindow/render/paint.rs
+++ b/kaku-gui/src/termwindow/render/paint.rs
@@ -251,8 +251,8 @@ impl crate::TermWindow {
                     } else {
                         tab_bar_height
                     };
-                let bottom_fill_height = padding_bottom + border.bottom.get() as f32;
-                let bottom_reserved_for_right_strip = bottom_fill_height
+                let bottom_fill_height = padding_bottom
+                    + border.bottom.get() as f32
                     + if self.config.tab_bar_at_bottom {
                         tab_bar_height
                     } else {
@@ -292,10 +292,9 @@ impl crate::TermWindow {
                 if right_fill_width > 0.0 {
                     let clamped_width = right_fill_width.min(window_width);
                     let right_fill_y = top_fill_height.min(window_height);
-                    let right_fill_height = (window_height
-                        - right_fill_y
-                        - bottom_reserved_for_right_strip.min(window_height))
-                    .max(0.0);
+                    let right_fill_height =
+                        (window_height - right_fill_y - bottom_fill_height.min(window_height))
+                            .max(0.0);
                     self.filled_rectangle(
                         &mut layers,
                         0,


### PR DESCRIPTION
When window_background_opacity < 1.0, the background fill strips did not account for tab bar height on the bottom side:

- bottom_fill_height was missing tab_bar_height (visible when tab bar is at bottom, which is the default)

This left an unfilled strip between the pane content and the bottom tab bar where the desktop showed through with blur but no background color.

Consolidate padding calculations into a shared DimensionContext and remove the now-redundant bottom_reserved_for_right_strip variable since bottom_fill_height now includes everything.

Visual bug
<img width="101" height="107" alt="image" src="https://github.com/user-attachments/assets/b80776e8-32f8-407f-a081-a9d5ed3bc121" />
