### PR TITLE
feat(ai-config): add opencode.jsonc support and refactor JSONC parser

### DIFF
--- a/kaku/src/main.rs
+++ b/kaku/src/main.rs
@@ -25,6 +25,7 @@ mod config_cmd;
 mod init;
 mod reset;
 mod update;
+mod utils;
 
 #[derive(Debug, Parser)]
 #[command(

--- a/kaku/src/utils.rs
+++ b/kaku/src/utils.rs
@@ -1,0 +1,57 @@
+/// Strips JSONC (JSON with Comments) comments from the input string.
+/// Handles both single-line (//) and multi-line (/* */) comments,
+/// while preserving comments inside string literals.
+pub fn strip_jsonc_comments(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    let mut in_string = false;
+
+    while let Some(c) = chars.next() {
+        if in_string {
+            out.push(c);
+            if c == '\\' {
+                if let Some(&next) = chars.peek() {
+                    out.push(next);
+                    chars.next();
+                }
+            } else if c == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if c == '"' {
+            in_string = true;
+            out.push(c);
+            continue;
+        }
+
+        if c == '/' {
+            if let Some(&next) = chars.peek() {
+                if next == '/' {
+                    for ch in chars.by_ref() {
+                        if ch == '\n' {
+                            out.push('\n');
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                if next == '*' {
+                    chars.next();
+                    while let Some(ch) = chars.next() {
+                        if ch == '*' && chars.peek() == Some(&'/') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                    continue;
+                }
+            }
+        }
+
+        out.push(c);
+    }
+
+    out
+}


### PR DESCRIPTION
## Summary

- Add support for `opencode.jsonc` (JSON with Comments) alongside `opencode.json` in AI config TUI
- Prefer `.jsonc` over `.json` when both exist, preserving user's chosen format
- Update `kaku init` to detect and preserve existing `.jsonc` config files
- Extract `strip_jsonc_comments` to shared `utils.rs` module to eliminate code duplication

## Changes

| File | Change |
|------|--------|
| `kaku/src/utils.rs` | **NEW** - Shared `strip_jsonc_comments` utility for parsing JSONC files |
| `kaku/src/main.rs` | Added `mod utils;` declaration |
| `kaku/src/ai_config/tui.rs` | Import shared utils, add `.jsonc` fallback logic, remove duplicate function |
| `kaku/src/init.rs` | Import shared utils, add `.jsonc` detection in setup flow, remove duplicate function |

## Motivation

OpenCode supports both `.json` and `.jsonc` config files. Users who prefer inline documentation via comments use `.jsonc`. This change ensures Kaku's AI Config TUI and `kaku init` properly handle both formats.

## Testing

- `cargo check -p kaku` ✅
- `cargo test -p kaku` ✅ (3/3 tests passed)