### PR TITLE
fix(shell): override TERM=xterm-256color for ssh sessions

### DIFF
--- a/assets/shell-integration/kaku.sh
+++ b/assets/shell-integration/kaku.sh
@@ -36,6 +36,15 @@ case "$TERM" in
   ;;
 esac
 
+# Remote machines typically don't have the "kaku" terminfo entry, so when
+# SSHing from a Kaku local shell (TERM=kaku), zsh plugins on the remote side
+# (autosuggestions, syntax-highlighting) fall back to broken rendering paths,
+# causing garbled display (e.g. "ls -lh" appearing as "lss s -lh").
+# Override TERM for ssh sessions the same way Kaku's built-in SSH domain does.
+if [[ "${TERM:-}" == "kaku" ]]; then
+  ssh() { TERM=xterm-256color command ssh "$@"; }
+fi
+
 # This function wraps bash-preexec.sh so that it can be included verbatim
 # in this file, even though it uses `return` to short-circuit in some cases.
 __wezterm_install_bash_prexec() {


### PR DESCRIPTION
When SSHing from a Kaku local shell, TERM=kaku is forwarded to the remote machine but TERMINFO_DIRS is not, so the remote has no kaku terminfo. This causes zsh plugins (autosuggestions, syntax-highlighting) to fall back to broken rendering paths, producing garbled display (e.g. "ls -lh" appearing as "lss s -lh").

Add an ssh wrapper to kaku.sh that applies the same TERM override already used by Kaku's built-in SSH domain (mux/src/ssh.rs:271).

https://github.com/tw93/Kaku/issues/112

🤖 Built with SMT <smt@agora.build>