### PR TITLE
fix: remove kaku.lua on reset

### DIFF
--- a/kaku/src/reset.rs
+++ b/kaku/src/reset.rs
@@ -108,6 +108,12 @@ mod imp {
             "removed Kaku backup directory",
             &mut report,
         )?;
+        remove_dir_if_exists(
+            config_home().join("kaku.lua"),
+            "removed Kaku config",
+            &mut report,
+        )?;
+
         remove_empty_kaku_config_dir(&mut report)?;
 
         report.print();


### PR DESCRIPTION
#115 
执行 `kaku reset` 时删除用户配置文件 `kaku.lua`，确保在版本更新后可以正确恢复到当前版本的默认配置。