### PR TITLE
fix(selection): preserve text selection during active terminal output

### DIFF
--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -2047,43 +2047,6 @@ impl TermWindow {
         }
     }
 
-    fn check_for_dirty_lines_and_invalidate_selection(&mut self, pane: &Arc<dyn Pane>) {
-        let dims = pane.get_dimensions();
-        let viewport = self
-            .get_viewport(pane.pane_id())
-            .unwrap_or(dims.physical_top);
-        let visible_range = viewport..viewport + dims.viewport_rows as StableRowIndex;
-        let seqno = self.selection(pane.pane_id()).seqno;
-        let dirty = pane.get_changed_since(visible_range, seqno);
-
-        if dirty.is_empty() {
-            return;
-        }
-        if pane.downcast_ref::<CopyOverlay>().is_none()
-            && pane.downcast_ref::<QuickSelectOverlay>().is_none()
-        {
-            // If any of the changed lines intersect with the
-            // selection, then we need to clear the selection, but not
-            // when the search overlay is active; the search overlay
-            // marks lines as dirty to force invalidate them for
-            // highlighting purpose but also manipulates the selection
-            // and we want to allow it to retain the selection it made!
-
-            let clear_selection =
-                if let Some(selection_range) = self.selection(pane.pane_id()).range.as_ref() {
-                    let selection_rows = selection_range.rows();
-                    selection_rows.into_iter().any(|row| dirty.contains(row))
-                } else {
-                    false
-                };
-
-            if clear_selection {
-                self.selection(pane.pane_id()).range.take();
-                self.selection(pane.pane_id()).origin.take();
-                self.selection(pane.pane_id()).seqno = pane.get_current_seqno();
-            }
-        }
-    }
 }
 
 impl TermWindow {

--- a/kaku-gui/src/termwindow/render/pane.rs
+++ b/kaku-gui/src/termwindow/render/pane.rs
@@ -38,7 +38,13 @@ impl crate::TermWindow {
             return self.paint_pane_box_model(pos);
         }
 
-        self.check_for_dirty_lines_and_invalidate_selection(&pos.pane);
+        // Don't auto-clear user selection due to dirty lines.
+        // Programs with frequent output (status bar animations, streaming logs)
+        // produce dirty lines every frame, causing selections to be instantly
+        // cleared on mouse release. Let user actions (click elsewhere, new
+        // selection, ESC) manage selection lifetime instead, consistent with
+        // Alacritty/iTerm2/Kitty behavior.
+        // (Removed: check_for_dirty_lines_and_invalidate_selection)
         /*
         let zone = {
             let dims = pos.pane.get_dimensions();


### PR DESCRIPTION
## Summary

- Remove `check_for_dirty_lines_and_invalidate_selection` which auto-cleared text selections when dirty lines overlapped with selected rows
- Programs with frequent output (status bar animations, streaming logs, spinners) produce dirty lines every frame, making it impossible to select and copy text while output is active
- Selection lifetime is now managed by user actions (click elsewhere, new selection, ESC), consistent with Alacritty/iTerm2/Kitty

## Problem

When running programs that continuously update the terminal (e.g., CLI tools with spinner animations or status bars), any text selection would be instantly cleared on mouse release. The per-frame dirty line check would detect the animation updates as "changed lines" and wipe the selection before the user could copy.

## Changes

| File | Change |
|------|--------|
| `kaku-gui/src/termwindow/mod.rs` | Removed `check_for_dirty_lines_and_invalidate_selection` function (37 lines) |
| `kaku-gui/src/termwindow/render/pane.rs` | Replaced call with explanatory comment |

This also eliminates the per-frame `get_changed_since()` heap allocation overhead from the render loop.

## Test plan

- [x] Run a program with continuous output (e.g., `top`, CLI tools with spinners)
- [x] Select text while output is active → selection persists after mouse release
- [x] Cmd+C copies correctly
- [x] CopyOverlay (Ctrl+Shift+X) and QuickSelect still work (independent seqno tracking)
- [x] Builds with no warnings on macOS