### PR TITLE
build: fix local Rust bootstrap and hook setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,13 @@
 git clone https://github.com/tw93/Kaku.git
 cd Kaku
 
-# Install required tools (cargo-nextest, nightly rustfmt)
+# Install Rust if it isn't already available (Homebrew keeps rustup keg-only)
+brew install rustup
+echo 'export PATH="/opt/homebrew/opt/rustup/bin:$HOME/.cargo/bin:$PATH"' >> ~/.zprofile
+exec zsh -l
+rustup default 1.93.0
+
+# Install required tools (cargo-nextest, cargo-watch, nightly rustfmt)
 make install-tools
 
 # Install pre-commit hook (format + test before each commit)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all fmt fmt-check build app dev check test install-tools test-webgpu-fallback
+.PHONY: all fmt fmt-check build app dev check test install-tools install-hooks test-webgpu-fallback
 
 all: build
 
@@ -48,10 +48,25 @@ fmt-check:
 	@echo "Format check passed."
 
 install-tools:
+	@if ! command -v cargo >/dev/null 2>&1 || ! command -v rustup >/dev/null 2>&1; then \
+		echo "Rust toolchain not found. Install rustup first, then re-run make install-tools."; \
+		echo "See CONTRIBUTING.md for the bootstrap steps."; \
+		exit 1; \
+	fi
 	cargo install cargo-nextest --locked
 	cargo install cargo-watch --locked
-	rustup toolchain install nightly --component rustfmt
+	rustup toolchain install nightly --profile minimal --component rustfmt
 	@echo "Tools installed."
+
+install-hooks:
+	@if [ ! -d .git ]; then \
+		echo "install-hooks must be run from a git checkout."; \
+		exit 1; \
+	fi
+	@mkdir -p .git/hooks
+	@printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' 'exec make fmt-check test' > .git/hooks/pre-commit
+	@chmod +x .git/hooks/pre-commit
+	@echo "Installed pre-commit hook at .git/hooks/pre-commit"
 
 test-webgpu-fallback:
 	./scripts/test_webgpu_fallback.sh --strict

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -65,6 +65,15 @@ resolve_build_targets() {
 	esac
 }
 
+require_command() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		echo "Missing required command: $1" >&2
+		echo "Install the Rust toolchain bootstrap first, then retry." >&2
+		echo "See CONTRIBUTING.md for setup instructions." >&2
+		exit 1
+	fi
+}
+
 ensure_rust_targets() {
 	local installed
 	local missing=()
@@ -89,6 +98,9 @@ for arg in "$@"; do
 	--native-arch) BUILD_ARCH="native" ;;
 	esac
 done
+
+require_command cargo
+require_command rustup
 
 APP_BUNDLE_SRC="assets/macos/Kaku.app"
 APP_BUNDLE_OUT="$OUT_DIR/$APP_NAME.app"


### PR DESCRIPTION
## Summary
- document the Rust bootstrap path for clean macOS machines
- make `make install-tools` fail fast with actionable guidance when Rust is missing
- add a working `make install-hooks` target and validate `scripts/build.sh` prerequisites

## Verification
- `zsh -lc "make fmt-check"`
- `tmpdir=$(mktemp -d) && git init -q "$tmpdir" && cp Makefile "$tmpdir"/Makefile && make -C "$tmpdir" install-hooks && sed -n "1,20p" "$tmpdir/.git/hooks/pre-commit"`
- `zsh -lc "make check"`
- `zsh -lc "make app"`
