### PR TITLE
ci: pin bundled shell vendors and validate app bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,32 @@ jobs:
 
           lipo -info target/universal/release/kaku
           lipo -info target/universal/release/kaku-gui
+
+  app-bundle:
+    name: App Bundle Validation
+    runs-on: macos-latest
+    needs: [check, test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.93.0
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+
+      - name: Build debug app bundle
+        run: |
+          set -o pipefail
+          ./scripts/build.sh --native-arch --app-only 2>&1 | sed '/has no symbols/d'
+
+      - name: Verify bundled shell plugins are pinned
+        run: |
+          test -f assets/vendor/zsh-autosuggestions/.kaku-vendor-ref
+          test -f assets/vendor/zsh-syntax-highlighting/.kaku-vendor-ref
+          test -f assets/vendor/zsh-completions/.kaku-vendor-ref
+          test -f assets/vendor/zsh-z/.kaku-vendor-ref
+          test -d dist/Kaku.app

--- a/scripts/download_vendor.sh
+++ b/scripts/download_vendor.sh
@@ -7,45 +7,55 @@ set -euo pipefail
 VENDOR_DIR="$(cd "$(dirname "$0")/../assets/vendor" && pwd)"
 mkdir -p "$VENDOR_DIR"
 
+download_pinned_repo() {
+	local step="$1"
+	local name="$2"
+	local repo="$3"
+	local ref="$4"
+	local dest="$VENDOR_DIR/$name"
+	local marker_file="$dest/.kaku-vendor-ref"
+	local archive_url="https://codeload.github.com/$repo/tar.gz/$ref"
+	local temp_dir
+	local extract_dir
+	local archive_path
+	local source_dir
+
+	echo "[$step/4] Syncing $name @ $ref..."
+	if [[ -f "$marker_file" ]] && [[ "$(cat "$marker_file")" == "$ref" ]]; then
+		echo "$name already pinned to $ref, skipping."
+		return
+	fi
+
+	temp_dir="$(mktemp -d)"
+	trap 'rm -rf "$temp_dir"' RETURN
+	extract_dir="$temp_dir/extract"
+	archive_path="$temp_dir/$name.tar.gz"
+	mkdir -p "$extract_dir"
+
+	curl --fail --location --silent --show-error --retry 3 --retry-delay 2 "$archive_url" --output "$archive_path"
+	tar -xzf "$archive_path" -C "$extract_dir"
+	source_dir="$(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+	if [[ -z "$source_dir" ]]; then
+		echo "Failed to unpack $name from $archive_url" >&2
+		exit 1
+	fi
+
+	rm -rf "$dest"
+	mv "$source_dir" "$dest"
+	printf '%s\n' "$ref" > "$marker_file"
+	trap - RETURN
+	rm -rf "$temp_dir"
+}
+
 echo "[0/4] Cleaning legacy vendor binaries..."
 rm -f "$VENDOR_DIR/starship" "$VENDOR_DIR/delta" "$VENDOR_DIR/zoxide"
 rm -rf "$VENDOR_DIR/completions" "$VENDOR_DIR/man"
 rm -f "$VENDOR_DIR/README.md" "$VENDOR_DIR/CHANGELOG.md" "$VENDOR_DIR/LICENSE"
 
-echo "[1/4] Cloning zsh-autosuggestions..."
-AUTOSUGGEST_DIR="$VENDOR_DIR/zsh-autosuggestions"
-if [[ ! -d "$AUTOSUGGEST_DIR" ]]; then
-	git clone --depth 1 https://github.com/zsh-users/zsh-autosuggestions "$AUTOSUGGEST_DIR"
-	rm -rf "$AUTOSUGGEST_DIR/.git"
-else
-	echo "zsh-autosuggestions already exists, skipping."
-fi
-
-echo "[2/4] Cloning zsh-syntax-highlighting..."
-SYNTAX_DIR="$VENDOR_DIR/zsh-syntax-highlighting"
-if [[ ! -d "$SYNTAX_DIR" ]]; then
-	git clone --depth 1 https://github.com/zsh-users/zsh-syntax-highlighting.git "$SYNTAX_DIR"
-	rm -rf "$SYNTAX_DIR/.git"
-else
-	echo "zsh-syntax-highlighting already exists, skipping."
-fi
-
-echo "[3/4] Cloning zsh-completions..."
-ZSH_COMPLETIONS_DIR="$VENDOR_DIR/zsh-completions"
-if [[ ! -d "$ZSH_COMPLETIONS_DIR" ]]; then
-	git clone --depth 1 https://github.com/zsh-users/zsh-completions.git "$ZSH_COMPLETIONS_DIR"
-	rm -rf "$ZSH_COMPLETIONS_DIR/.git"
-else
-	echo "zsh-completions already exists, skipping."
-fi
-
-echo "[4/4] Cloning zsh-z..."
-ZSH_Z_DIR="$VENDOR_DIR/zsh-z"
-if [[ ! -d "$ZSH_Z_DIR" ]]; then
-	git clone --depth 1 https://github.com/agkozak/zsh-z "$ZSH_Z_DIR"
-	rm -rf "$ZSH_Z_DIR/.git"
-else
-	echo "zsh-z already exists, skipping."
-fi
+# Pin external shell integrations to exact commits so app/release artifacts stay reproducible.
+download_pinned_repo "1" "zsh-autosuggestions" "zsh-users/zsh-autosuggestions" "85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5"
+download_pinned_repo "2" "zsh-syntax-highlighting" "zsh-users/zsh-syntax-highlighting" "1d85c692615a25fe2293bdd44b34c217d5d2bf04"
+download_pinned_repo "3" "zsh-completions" "zsh-users/zsh-completions" "84615f3d0b0e943d5b1de862c9552e572c8e70bb"
+download_pinned_repo "4" "zsh-z" "agkozak/zsh-z" "cf9225feebfae55e557e103e95ce20eca5eff270"
 
 echo "Vendor dependencies downloaded to $VENDOR_DIR"


### PR DESCRIPTION
## Summary
- pin bundled zsh plugin vendors to exact commits instead of downloading upstream HEAD
- make the vendor sync idempotent and leave a `.kaku-vendor-ref` marker for verification
- add CI coverage for the real app bundle packaging path used by releases

## Verification
- `bash -n scripts/download_vendor.sh`
- `./scripts/download_vendor.sh && ./scripts/download_vendor.sh`
- `zsh -lc "make app"`
