### PR TITLE
feat: add tab renaming and reordering

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -686,6 +686,7 @@ pub enum KeyAssignment {
     ReloadConfiguration,
     MoveTabRelative(isize),
     MoveTab(usize),
+    RenameTab,
     ScrollByPage(NotNan<f64>),
     ScrollByLine(isize),
     ScrollByCurrentEventWheelDelta,

--- a/kaku-gui/src/commands.rs
+++ b/kaku-gui/src/commands.rs
@@ -243,6 +243,7 @@ impl CommandDef {
             ActivateTabRelative(-1),
             ActivateTabRelative(1),
             ActivateLastTab,
+            RenameTab,
             MoveTabRelative(-1),
             MoveTabRelative(1),
             TogglePaneZoomState,
@@ -359,6 +360,7 @@ impl CommandDef {
                     | ActivateTabRelative(_)
                     | ActivateLastTab
                     | MoveTabRelative(_)
+                    | RenameTab
                     | TogglePaneZoomState
                     | AdjustPaneSize(_, _)
                     | ActivatePaneDirection(_)
@@ -746,6 +748,7 @@ impl CommandDef {
                     ShowTabNavigator => 33,
                     MoveTabRelative(-1) => 40,
                     MoveTabRelative(1) => 41,
+                    RenameTab => 42,
                     PaneSelect(PaneSelectArguments {
                         mode: PaneSelectMode::Activate,
                         ..
@@ -1748,6 +1751,14 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             menubar: &["Kaku"],
             icon: None,
         },
+        RenameTab => CommandDef {
+            brief: "Rename Tab".into(),
+            doc: "Rename the current tab".into(),
+            keys: vec![(Modifiers::CTRL.union(Modifiers::SHIFT), "r".into())],
+            args: &[ArgType::ActiveTab],
+            menubar: &["Window"],
+            icon: None,
+        },
         MoveTabRelative(-1) => CommandDef {
             brief: "Move Tab Left".into(),
             doc: "Move current tab left".into(),
@@ -2548,6 +2559,7 @@ fn compute_default_actions() -> Vec<KeyAssignment> {
         ActivateTabRelative(1),
         ActivateWindowRelative(-1),
         ActivateWindowRelative(1),
+        RenameTab,
         MoveTabRelative(-1),
         MoveTabRelative(1),
         AdjustPaneSize(PaneDirection::Left, 5),

--- a/kaku-gui/src/overlay/mod.rs
+++ b/kaku-gui/src/overlay/mod.rs
@@ -13,6 +13,7 @@ pub mod debug;
 pub mod launcher;
 pub mod prompt;
 pub mod quickselect;
+pub mod rename_tab;
 pub mod selector;
 
 #[cfg(not(target_os = "macos"))]

--- a/kaku-gui/src/overlay/rename_tab.rs
+++ b/kaku-gui/src/overlay/rename_tab.rs
@@ -1,0 +1,78 @@
+use mux::tab::TabId;
+use mux::termwiztermtab::TermWizTerminal;
+use mux::Mux;
+use termwiz::input::{InputEvent, KeyCode, KeyEvent};
+use termwiz::lineedit::*;
+use termwiz::surface::Change;
+use termwiz::terminal::Terminal;
+
+struct RenameHost {
+    history: BasicHistory,
+}
+
+impl RenameHost {
+    fn new() -> Self {
+        Self {
+            history: BasicHistory::default(),
+        }
+    }
+}
+
+impl LineEditorHost for RenameHost {
+    fn history(&mut self) -> &mut dyn History {
+        &mut self.history
+    }
+
+    fn resolve_action(
+        &mut self,
+        event: &InputEvent,
+        editor: &mut LineEditor<'_>,
+    ) -> Option<Action> {
+        let (line, _cursor) = editor.get_line_and_cursor();
+        if line.is_empty()
+            && matches!(
+                event,
+                InputEvent::Key(KeyEvent {
+                    key: KeyCode::Escape,
+                    ..
+                })
+            )
+        {
+            Some(Action::Cancel)
+        } else {
+            None
+        }
+    }
+}
+
+pub fn show_rename_tab_overlay(
+    mut term: TermWizTerminal,
+    tab_id: TabId,
+    current_title: String,
+) -> anyhow::Result<()> {
+    term.no_grab_mouse_in_raw_mode();
+    term.render(&[Change::Text(
+        "Enter new tab name (Escape to cancel):\r\n".to_string(),
+    )])?;
+
+    let mut host = RenameHost::new();
+    let mut editor = LineEditor::new(&mut term);
+    editor.set_prompt("> ");
+    let line = editor.read_line_with_optional_initial_value(&mut host, Some(&current_title))?;
+
+    if let Some(new_title) = line {
+        let new_title = new_title.trim().to_string();
+        if !new_title.is_empty() {
+            promise::spawn::spawn_into_main_thread(async move {
+                let mux = Mux::get();
+                if let Some(tab) = mux.get_tab(tab_id) {
+                    tab.set_title(&new_title);
+                }
+                anyhow::Result::<()>::Ok(())
+            })
+            .detach();
+        }
+    }
+
+    Ok(())
+}

--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -3165,6 +3165,23 @@ impl TermWindow {
         self.move_tab(tab)
     }
 
+    fn show_rename_tab_prompt(&mut self) {
+        let mux = Mux::get();
+        let tab = match mux.get_active_tab_for_window(self.mux_window_id) {
+            Some(tab) => tab,
+            None => return,
+        };
+
+        let tab_id = tab.tab_id();
+        let current_title = tab.get_title();
+
+        let (overlay, future) = start_overlay(self, &tab, move |_tab_id, term| {
+            crate::overlay::rename_tab::show_rename_tab_overlay(term, tab_id, current_title)
+        });
+        self.assign_overlay(tab.tab_id(), overlay);
+        promise::spawn::spawn(future).detach();
+    }
+
     pub fn perform_key_assignment(
         &mut self,
         pane: &Arc<dyn Pane>,
@@ -3364,6 +3381,7 @@ impl TermWindow {
             ReloadConfiguration => {}
             MoveTab(n) => self.move_tab(*n)?,
             MoveTabRelative(n) => self.move_tab_relative(*n)?,
+            RenameTab => self.show_rename_tab_prompt(),
             ScrollByPage(n) => self.scroll_by_page(**n, pane)?,
             ScrollByLine(n) => self.scroll_by_line(*n, pane)?,
             ScrollByCurrentEventWheelDelta => self.scroll_by_current_event_wheel_delta(pane)?,


### PR DESCRIPTION
## Summary
Fixes #153

Adds two features requested in the issue:
1. **Tab renaming** — Press `Ctrl+Shift+R` to open an inline prompt overlay where you can type a new name for the current tab. The current title is pre-filled for easy editing. Press Enter to confirm or Escape to cancel.
2. **Tab reordering** — Already supported via `Ctrl+Shift+PageUp` (move left) and `Ctrl+Shift+PageDown` (move right). This PR ensures the rename command is properly surfaced alongside reordering in the command palette.

## Changes
- `config/src/keyassignment.rs` — Added `RenameTab` variant to `KeyAssignment` enum
- `kaku-gui/src/overlay/rename_tab.rs` — New overlay module for the rename tab prompt (uses `LineEditor` from termwiz, same pattern as existing prompt overlay)
- `kaku-gui/src/overlay/mod.rs` — Registered the new `rename_tab` overlay module
- `kaku-gui/src/termwindow/mod.rs` — Added `show_rename_tab_prompt()` method and wired `RenameTab` in `perform_key_assignment`
- `kaku-gui/src/commands.rs` — Added `RenameTab` command definition with keybinding, priority ranking, palette visibility, and default action registration

## How to test
1. Build with `cargo build`
2. Launch the terminal and open multiple tabs
3. Press `Ctrl+Shift+R` to rename the current tab — type a new name and press Enter
4. Press `Ctrl+Shift+PageUp/PageDown` to reorder tabs
5. Open the command palette (`Cmd+Shift+P`) and search for "Rename Tab" or "Move Tab"

---
Generated by Orbit (hunter-pro)