### PR TITLE
fix: harden zsh starship RPROMPT fallback

### DIFF
--- a/assets/shell-integration/setup_zsh.sh
+++ b/assets/shell-integration/setup_zsh.sh
@@ -389,8 +389,12 @@ if command -v starship &> /dev/null; then
                 if [[ "\${_kaku_starship_rprompt_cmd}" == *starship*'prompt --right'* ]]; then
                     evaled="\$(_kaku_render_starship_rprompt)"
                 else
-                    local cmd="\${_kaku_starship_rprompt_cmd#\\$\\(}"
-                    cmd="\${cmd%\\)}"
+                    local cmd="\${_kaku_starship_rprompt_cmd}"
+                    # Avoid zsh pattern parsing here; strip a literal \$(
+                    # prefix and trailing ) via slicing instead.
+                    if [[ "\${cmd[1]}" == '$' && "\${cmd[2]}" == '(' && "\${cmd[-1]}" == ')' ]]; then
+                        cmd="\${cmd[3,-2]}"
+                    fi
                     evaled="\$(eval "\$cmd" 2>/dev/null)"
                 fi
                 RPROMPT="\$evaled"

--- a/assets/shell-integration/tests/starship_rprompt_smoke.sh
+++ b/assets/shell-integration/tests/starship_rprompt_smoke.sh
@@ -116,4 +116,40 @@ case "$output" in
     ;;
 esac
 
+seeded_output=""
+if ! seeded_output="$(
+  TERM=xterm-256color \
+  PATH="$tmp_dir/bin:$PATH" \
+  HOME="$HOME" \
+  ZDOTDIR="$ZDOTDIR" \
+  zsh -f -c '
+source "$HOME/.config/kaku/zsh/kaku.zsh"
+RPROMPT='\''$(echo fake-right-prompt)'\''
+_kaku_starship_rprompt_cmd="$RPROMPT"
+_kaku_fix_starship_rprompt
+print -r -- "__KAKU_SEEDED__:$RPROMPT"
+' 2>&1
+)"; then
+  echo "starship_rprompt: seeded zsh exited non-zero:" >&2
+  echo "$seeded_output" >&2
+  exit 1
+fi
+
+case "$seeded_output" in
+  *__KAKU_SEEDED__:fake-right-prompt* ) ;;
+  * )
+    echo "starship_rprompt: seeded sentinel missing or wrong output:" >&2
+    echo "$seeded_output" >&2
+    exit 1
+    ;;
+esac
+
+case "$seeded_output" in
+  *"closing brace expected"* | *"bad pattern"* )
+    echo "starship_rprompt: seeded zsh pattern error:" >&2
+    echo "$seeded_output" >&2
+    exit 1
+    ;;
+esac
+
 echo "starship_rprompt smoke test passed"


### PR DESCRIPTION
## Summary
- avoid zsh pattern parsing when stripping a literal `$(...)` wrapper from seeded RPROMPT commands
- preserve the existing starship fast path and only harden the fallback path
- extend the smoke test to cover the seeded-command path that previously raised `bad pattern` / `closing brace expected`

## Repro
```sh
zsh -fc 'source ~/.config/kaku/zsh/kaku.zsh >/dev/null 2>&1; RPROMPT="\\$(echo fake-right-prompt)"; _kaku_starship_rprompt_cmd="$RPROMPT"; _kaku_fix_starship_rprompt'
```
Before this patch that path could raise `_kaku_fix_starship_rprompt:13: bad pattern: $(` or `closing brace expected`.

## Testing
```sh
bash assets/shell-integration/tests/starship_rprompt_smoke.sh
```
Passed locally.