### PR TITLE
feat(i18n): add bilingual UI support (English/Chinese)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,6 +2521,7 @@ dependencies = [
  "termwiz-funcs",
  "toml 0.8.23",
  "umask",
+ "unicode-width 0.2.0",
  "url",
  "wezterm-client",
  "wezterm-gui-subcommands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,7 @@ uds_windows = "1.1"
 umask = { path = "crates/umask" }
 unicode-normalization = "0.1.24"
 unicode-segmentation = "1.12"
+unicode-width = "0.2"
 url = "2"
 url-funcs = { path = "lua-api-crates/url-funcs" }
 utf8parse = "0.2"

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -194,6 +194,10 @@ pub struct Config {
     /// by the colors setting.
     pub color_scheme: Option<String>,
 
+    /// UI language: "en" for English (default), "zh" for Chinese.
+    #[dynamic(default)]
+    pub language: Option<String>,
+
     /// Named color schemes
     #[dynamic(default)]
     pub color_schemes: HashMap<String, Palette>,

--- a/config/src/i18n.rs
+++ b/config/src/i18n.rs
@@ -1,0 +1,246 @@
+use lazy_static::lazy_static;
+use parking_lot::RwLock;
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Language {
+    En,
+    Zh,
+}
+
+impl Language {
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "zh" | "chinese" | "中文" => Language::Zh,
+            _ => Language::En,
+        }
+    }
+
+    pub fn as_config_str(&self) -> &'static str {
+        match self {
+            Language::En => "en",
+            Language::Zh => "zh",
+        }
+    }
+}
+
+lazy_static! {
+    static ref LANGUAGE: RwLock<Language> = RwLock::new(Language::En);
+    static ref ZH_MAP: HashMap<&'static str, &'static str> = build_zh();
+}
+
+pub fn set_language(lang: Language) {
+    *LANGUAGE.write() = lang;
+}
+
+pub fn get_language() -> Language {
+    *LANGUAGE.read()
+}
+
+pub fn t(key: &'static str) -> Cow<'static, str> {
+    if *LANGUAGE.read() == Language::En {
+        return Cow::Borrowed(key);
+    }
+    ZH_MAP
+        .get(key)
+        .map(|&v| Cow::Borrowed(v))
+        .unwrap_or(Cow::Borrowed(key))
+}
+
+pub fn t_display(key: &str) -> String {
+    if *LANGUAGE.read() == Language::En {
+        return key.to_string();
+    }
+    ZH_MAP
+        .get(key)
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| key.to_string())
+}
+
+fn build_zh() -> HashMap<&'static str, &'static str> {
+    let mut m = HashMap::new();
+
+    // ── Settings TUI: field labels ──
+    m.insert("Theme", "主题");
+    m.insert("Font", "字体");
+    m.insert("Font Size", "字号");
+    m.insert("Line Height", "行高");
+    m.insert("Global Hotkey", "全局热键");
+    m.insert("Kaku Assistant", "Kaku 助手");
+    m.insert("Tab Bar Position", "标签栏位置");
+    m.insert("Copy on Select", "选中复制");
+    m.insert("Shadow", "阴影");
+    m.insert("Bell Tab Indicator", "响铃标签指示");
+    m.insert("Bell Dock Badge", "响铃 Dock 角标");
+    m.insert("Language", "语言");
+
+    // ── Settings TUI: chrome ──
+    m.insert("Settings", "设置");
+    m.insert("save and apply changes", "保存并应用更改");
+    m.insert("open full config", "打开完整配置");
+    m.insert(" Select: ", " 选择：");
+    m.insert(" Edit: ", " 编辑：");
+    m.insert(": Save  ", "：保存  ");
+    m.insert(": Cancel ", "：取消 ");
+
+    // ── Settings TUI: option display values ──
+    m.insert("On", "开");
+    m.insert("Off", "关");
+    m.insert("Bottom", "底部");
+    m.insert("Top", "顶部");
+    m.insert("English", "English");
+    m.insert("中文", "中文");
+
+    // ── macOS menu titles ──
+    m.insert("Edit", "编辑");
+    m.insert("View", "视图");
+    m.insert("Window", "窗口");
+    m.insert("Help", "帮助");
+
+    // ── macOS menu items ──
+    m.insert("Settings...", "设置...");
+    m.insert("Check for Updates...", "检查更新...");
+    m.insert("Set as Default Terminal", "设为默认终端");
+    m.insert("Services", "服务");
+
+    // ── Command palette: commands ──
+    m.insert("Paste primary selection", "粘贴主选区");
+    m.insert("Copy to primary selection", "复制到主选区");
+    m.insert("Copy to clipboard", "复制到剪贴板");
+    m.insert(
+        "Copy to clipboard and primary selection",
+        "复制到剪贴板和主选区",
+    );
+    m.insert("Paste from clipboard", "从剪贴板粘贴");
+    m.insert("Toggle Full Screen", "切换全屏");
+    m.insert("Always on Top", "窗口置顶");
+    m.insert("Always on Bottom", "窗口置底");
+    m.insert("Normal", "正常");
+    m.insert("Minimize", "最小化");
+    m.insert("Show/Restore Window", "显示/恢复窗口");
+    m.insert("Hide Kaku", "隐藏 Kaku");
+    m.insert("New Window", "新建窗口");
+    m.insert("Clear Scrollback", "清除回滚缓冲");
+    m.insert("Clear the scrollback and viewport", "清除回滚缓冲和视口");
+    m.insert("Search", "搜索");
+    m.insert("Search pane output", "搜索面板输出");
+    m.insert("Kaku Doctor", "Kaku 诊断");
+    m.insert(
+        "Prompt the user to choose from a list",
+        "提示用户从列表中选择",
+    );
+    m.insert("Prompt the user for confirmation", "提示用户确认");
+    m.insert(
+        "Prompt the user for a line of text",
+        "提示用户输入文本",
+    );
+    m.insert("QuickSelect", "快速选择");
+    m.insert("Enter QuickSelect mode", "进入快速选择模式");
+    m.insert(
+        "Enter Emoji / Character selection mode",
+        "进入表情/字符选择模式",
+    );
+    m.insert("Select Pane", "选择面板");
+    m.insert("Swap a pane with the active pane", "与活动面板交换");
+    m.insert(
+        "Swap a pane with the active pane, keeping focus",
+        "与活动面板交换（保持焦点）",
+    );
+    m.insert("Move Pane to New Tab", "移动面板到新标签页");
+    m.insert("Move Pane to New Window", "移动面板到新窗口");
+    m.insert("Decrease Font Size", "减小字号");
+    m.insert("Increase Font Size", "增大字号");
+    m.insert("Reset Font Size", "重置字号");
+    m.insert("Reset Window & Font Size", "重置窗口和字号");
+    m.insert("New Tab", "新建标签页");
+    m.insert("Close Tab", "关闭标签页");
+    m.insert("Close Pane", "关闭面板");
+    m.insert("Close current Pane", "关闭当前面板");
+    m.insert("Reopen Last Closed Tab", "重新打开上次关闭的标签页");
+    m.insert("Previous Window", "上一个窗口");
+    m.insert("Next Window", "下一个窗口");
+    m.insert("Previous Window (No Wrap)", "上一个窗口（不循环）");
+    m.insert("Next Window (No Wrap)", "下一个窗口（不循环）");
+    m.insert("Previous Tab", "上一个标签页");
+    m.insert("Next Tab", "下一个标签页");
+    m.insert(
+        "Reload configuration (disabled)",
+        "重新加载配置（已禁用）",
+    );
+    m.insert("Quit Kaku", "退出 Kaku");
+    m.insert("Move Tab Left", "向左移动标签页");
+    m.insert("Move Tab Right", "向右移动标签页");
+    m.insert("Scroll Up One Page", "向上翻一页");
+    m.insert("Scroll Down One Page", "向下翻一页");
+    m.insert("Scroll to Bottom", "滚动到底部");
+    m.insert("Scroll to Top", "滚动到顶部");
+    m.insert("Activate Copy Mode", "激活复制模式");
+    m.insert("Split Pane Top/Bottom", "上下分割面板");
+    m.insert("Split Pane Left/Right", "左右分割面板");
+    m.insert("Resize Split Left", "向左调整分割线");
+    m.insert("Resize Split Right", "向右调整分割线");
+    m.insert("Resize Split Up", "向上调整分割线");
+    m.insert("Resize Split Down", "向下调整分割线");
+    m.insert("Activate Pane Left", "激活左侧面板");
+    m.insert("Activate Pane Right", "激活右侧面板");
+    m.insert("Activate Pane Up", "激活上方面板");
+    m.insert("Activate Pane Down", "激活下方面板");
+    m.insert("Zoom Pane", "面板缩放");
+    m.insert("Last Active Tab", "上一个活动标签页");
+    m.insert("Clear the key table stack", "清除按键表栈");
+    m.insert("Open link at mouse cursor", "打开鼠标处链接");
+    m.insert("Launcher", "启动器");
+    m.insert("Tab Navigator", "标签页导航");
+    m.insert("AI Config", "AI 配置");
+    m.insert("Yazi File Manager", "Yazi 文件管理器");
+    m.insert("Remote Files", "远程文件");
+    m.insert("Star on GitHub", "GitHub 加星");
+    m.insert("Discuss on GitHub", "GitHub 讨论");
+    m.insert("Report Issue", "报告问题");
+    m.insert("Does nothing", "无操作");
+    m.insert("Command Palette", "命令面板");
+    m.insert("Toggle Split Direction", "切换分割方向");
+    m.insert(
+        "Detach the domain of the active pane",
+        "断开活动面板的域",
+    );
+    m.insert("Detach the default domain", "断开默认域");
+    m.insert("Pop the current key table", "弹出当前按键表");
+    m.insert("Activate right-most tab", "激活最右标签页");
+    m.insert(
+        "Reset the terminal emulation state in the current pane",
+        "重置当前面板的终端仿真状态",
+    );
+
+    // ── Launcher overlay ──
+    m.insert("Pane Encoding", "面板编码");
+    m.insert("(default shell)", "（默认 Shell）");
+    m.insert("Attach", "连接");
+    m.insert("Switch to workspace", "切换工作区");
+    m.insert("Create new Workspace", "创建新工作区");
+    m.insert("current is", "当前为");
+    m.insert("panes", "个面板");
+    m.insert("Set pane encoding to", "设置面板编码为");
+    m.insert(
+        "Select encoding  |  Enter = set  |  Esc = back  |  / = filter",
+        "选择编码  |  Enter = 设置  |  Esc = 返回  |  / = 筛选",
+    );
+    m.insert("domain", "域");
+
+    // ── Commands: dynamic format parts ──
+    m.insert("Attach Domain", "连接域");
+    m.insert("Detach Domain", "断开域");
+    m.insert("Domain", "域");
+    m.insert("Lazygit", "Lazygit");
+    m.insert(
+        "Activate the tab to the left (no wrapping)",
+        "向左激活标签页（不循环）",
+    );
+    m.insert(
+        "Activate the tab to the right (no wrapping)",
+        "向右激活标签页（不循环）",
+    );
+
+    m
+}

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -30,6 +30,7 @@ mod daemon;
 mod exec_domain;
 mod font;
 mod frontend;
+pub mod i18n;
 pub mod keyassignment;
 mod keys;
 pub mod lua;
@@ -1119,6 +1120,9 @@ impl ConfigInner {
 
         match config {
             Ok(config) => {
+                if let Some(ref lang) = config.language {
+                    i18n::set_language(i18n::Language::from_str(lang));
+                }
                 self.config = Arc::new(config);
                 self.error.take();
                 self.generation += 1;
@@ -1198,6 +1202,9 @@ impl ConfigInner {
     }
 
     fn use_this_config(&mut self, cfg: Config) {
+        if let Some(ref lang) = cfg.language {
+            i18n::set_language(i18n::Language::from_str(lang));
+        }
         self.config = Arc::new(cfg);
         self.error.take();
         self.generation += 1;

--- a/kaku-gui/src/commands.rs
+++ b/kaku-gui/src/commands.rs
@@ -1,4 +1,5 @@
 use crate::inputmap::InputMap;
+use config::i18n::t;
 use config::keyassignment::{ClipboardCopyDestination, ClipboardPasteSource, PaneEncoding, *};
 use config::window::WindowLevel;
 use config::{ConfigHandle, DeferredKeyCode};
@@ -477,11 +478,11 @@ impl CommandDef {
                 Some(label) => label.to_string(),
                 None => match cmd.args.as_ref() {
                     Some(args) => args.join(" "),
-                    None => "(default shell)".to_string(),
+                    None => t("(default shell)").into_owned(),
                 },
             };
             result.push(ExpandedCommand {
-                brief: format!("{label} (New Tab)").into(),
+                brief: format!("{label} ({})", t("New Tab")).into(),
                 doc: "".into(),
                 keys: vec![],
                 action: KeyAssignment::SpawnCommandInNewTab(cmd.clone()),
@@ -513,7 +514,7 @@ impl CommandDef {
                 if dom.spawnable() {
                     if dom.state() == DomainState::Attached {
                         result.push(ExpandedCommand {
-                            brief: format!("New Tab (Domain {label})").into(),
+                            brief: format!("{} ({} {label})", t("New Tab"), t("Domain")).into(),
                             doc: "".into(),
                             keys: vec![],
                             action: KeyAssignment::SpawnCommandInNewTab(SpawnCommand {
@@ -525,7 +526,7 @@ impl CommandDef {
                         });
                     } else {
                         result.push(ExpandedCommand {
-                            brief: format!("Attach Domain {label}").into(),
+                            brief: format!("{} {label}", t("Attach Domain")).into(),
                             doc: "".into(),
                             keys: vec![],
                             action: KeyAssignment::AttachDomain(name.to_string()),
@@ -545,7 +546,7 @@ impl CommandDef {
                         continue;
                     }
                     result.push(ExpandedCommand {
-                        brief: format!("Detach Domain {label}").into(),
+                        brief: format!("{} {label}", t("Detach Domain")).into(),
                         doc: "".into(),
                         keys: vec![],
                         action: KeyAssignment::DetachDomain(SpawnTabDomain::DomainName(
@@ -561,7 +562,7 @@ impl CommandDef {
             for workspace in mux.iter_workspaces() {
                 if workspace != active_workspace {
                     result.push(ExpandedCommand {
-                        brief: format!("Switch to workspace {workspace}").into(),
+                        brief: format!("{} {workspace}", t("Switch to workspace")).into(),
                         doc: "".into(),
                         keys: vec![],
                         action: KeyAssignment::SwitchToWorkspace {
@@ -574,7 +575,7 @@ impl CommandDef {
                 }
             }
             result.push(ExpandedCommand {
-                brief: "Create new Workspace".into(),
+                brief: t("Create new Workspace"),
                 doc: "".into(),
                 keys: vec![],
                 action: KeyAssignment::SwitchToWorkspace {
@@ -823,7 +824,8 @@ impl CommandDef {
                 let rank = command_rank_for_menu(title, &cmd.action);
                 let group = separator_group_for_menu(title, rank);
 
-                let mut submenu = main_menu.get_or_create_sub_menu(&cmd.menubar[0], |menu| {
+                let menu_title = config::i18n::t_display(cmd.menubar[0]);
+                let mut submenu = main_menu.get_or_create_sub_menu(&menu_title, |menu| {
                     if cmd.menubar[0] == "Window" {
                         menu.assign_as_windows_menu();
                         // macOS will insert stuff at the top and bottom, so we add
@@ -844,8 +846,9 @@ impl CommandDef {
 
                         menu.add_item(&MenuItem::new_separator());
 
+                        let settings_label = config::i18n::t_display("Settings...");
                         let settings_item = MenuItem::new_with(
-                            "Settings...",
+                            &settings_label,
                             Some(kaku_perform_key_assignment_sel),
                             ",",
                         );
@@ -856,8 +859,9 @@ impl CommandDef {
                         ));
                         menu.add_item(&settings_item);
 
+                        let check_update_label = config::i18n::t_display("Check for Updates...");
                         let check_update = MenuItem::new_with(
-                            "Check for Updates...",
+                            &check_update_label,
                             Some(kaku_perform_key_assignment_sel),
                             "",
                         );
@@ -866,8 +870,9 @@ impl CommandDef {
                         ));
                         menu.add_item(&check_update);
 
+                        let set_default_terminal_label = config::i18n::t_display("Set as Default Terminal");
                         let set_default_terminal_item = MenuItem::new_with(
-                            "Set as Default Terminal",
+                            &set_default_terminal_label,
                             Some(kaku_perform_key_assignment_sel),
                             "",
                         );
@@ -883,9 +888,10 @@ impl CommandDef {
 
                         menu.add_item(&MenuItem::new_separator());
 
-                        let services_menu = Menu::new_with_title("Services");
+                        let services_label = config::i18n::t_display("Services");
+                        let services_menu = Menu::new_with_title(&services_label);
                         services_menu.assign_as_services_menu();
-                        let services_item = MenuItem::new_with("Services", None, "");
+                        let services_item = MenuItem::new_with(&services_label, None, "");
                         menu.add_item(&services_item);
                         services_item.set_sub_menu(&services_menu);
 
@@ -1057,7 +1063,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
 
     Some(match action {
         PasteFrom(ClipboardPasteSource::PrimarySelection) => CommandDef {
-            brief: "Paste primary selection".into(),
+            brief: t("Paste primary selection"),
             doc: "Pastes text from the primary selection".into(),
             keys: vec![(Modifiers::SHIFT, "Insert".into())],
             args: &[ArgType::ActivePane],
@@ -1069,7 +1075,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             destination: ClipboardCopyDestination::PrimarySelection,
         }
         | CopyTo(ClipboardCopyDestination::PrimarySelection) => CommandDef {
-            brief: "Copy to primary selection".into(),
+            brief: t("Copy to primary selection"),
             doc: "Copies text to the primary selection".into(),
             keys: vec![(Modifiers::CTRL, "Insert".into())],
             args: &[ArgType::ActivePane],
@@ -1081,7 +1087,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             destination: ClipboardCopyDestination::Clipboard,
         }
         | CopyTo(ClipboardCopyDestination::Clipboard) => CommandDef {
-            brief: "Copy to clipboard".into(),
+            brief: t("Copy to clipboard"),
             doc: "Copies text to the clipboard".into(),
             keys: vec![
                 (Modifiers::SUPER, "c".into()),
@@ -1096,7 +1102,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             destination: ClipboardCopyDestination::ClipboardAndPrimarySelection,
         }
         | CopyTo(ClipboardCopyDestination::ClipboardAndPrimarySelection) => CommandDef {
-            brief: "Copy to clipboard and primary selection".into(),
+            brief: t("Copy to clipboard and primary selection"),
             doc: "Copies text to the clipboard and the primary selection".into(),
             keys: vec![(Modifiers::CTRL, "Insert".into())],
             args: &[ArgType::ActivePane],
@@ -1104,7 +1110,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         PasteFrom(ClipboardPasteSource::Clipboard) => CommandDef {
-            brief: "Paste from clipboard".into(),
+            brief: t("Paste from clipboard"),
             doc: "Pastes text from the clipboard".into(),
             keys: vec![
                 (Modifiers::SUPER, "v".into()),
@@ -1115,7 +1121,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ToggleFullScreen => CommandDef {
-            brief: "Toggle Full Screen".into(),
+            brief: t("Toggle Full Screen"),
             doc: "Toggle full screen mode".into(),
             keys: vec![(Modifiers::CTRL.union(Modifiers::SUPER), "f".into())],
             args: &[ArgType::ActiveWindow],
@@ -1123,7 +1129,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ToggleAlwaysOnTop => CommandDef {
-            brief: "Always on Top".into(),
+            brief: t("Always on Top"),
             doc: "Keep window above others".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "UpArrow".into())],
             args: &[ArgType::ActiveWindow],
@@ -1131,7 +1137,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ToggleAlwaysOnBottom => CommandDef {
-            brief: "Always on Bottom".into(),
+            brief: t("Always on Bottom"),
             doc: "Keep window behind others".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "DownArrow".into())],
             args: &[ArgType::ActiveWindow],
@@ -1139,7 +1145,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         SetWindowLevel(WindowLevel::AlwaysOnTop) => CommandDef {
-            brief: "Always on Top".into(),
+            brief: t("Always on Top"),
             doc: "Set the window level to be on top of other windows.".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1147,7 +1153,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         SetWindowLevel(WindowLevel::Normal) => CommandDef {
-            brief: "Normal".into(),
+            brief: t("Normal"),
             doc: "Set window level to normal".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1155,7 +1161,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         SetWindowLevel(WindowLevel::AlwaysOnBottom) => CommandDef {
-            brief: "Always on Bottom".into(),
+            brief: t("Always on Bottom"),
             doc: "Set window to remain behind all other windows.".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1163,7 +1169,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         Hide => CommandDef {
-            brief: "Minimize".into(),
+            brief: t("Minimize"),
             doc: "Minimize current window".into(),
             keys: vec![(Modifiers::SUPER, "m".into())],
             args: &[ArgType::ActiveWindow],
@@ -1171,7 +1177,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         Show => CommandDef {
-            brief: "Show/Restore Window".into(),
+            brief: t("Show/Restore Window"),
             doc: "Show/Restore the current window".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1179,7 +1185,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         HideApplication => CommandDef {
-            brief: "Hide Kaku".into(),
+            brief: t("Hide Kaku"),
             doc: "Hide all Kaku windows".into(),
             keys: vec![(Modifiers::SUPER, "h".into())],
             args: &[],
@@ -1187,7 +1193,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         SpawnWindow => CommandDef {
-            brief: "New Window".into(),
+            brief: t("New Window"),
             doc: "Open a new window".into(),
             keys: vec![(Modifiers::SUPER, "n".into())],
             args: &[],
@@ -1195,7 +1201,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ClearScrollback(ScrollbackEraseMode::ScrollbackOnly) => CommandDef {
-            brief: "Clear Scrollback".into(),
+            brief: t("Clear Scrollback"),
             doc: "Clear scrollback history".into(),
             keys: vec![(Modifiers::SUPER, "k".into())],
             args: &[ArgType::ActivePane],
@@ -1203,7 +1209,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ClearScrollback(ScrollbackEraseMode::ScrollbackAndViewport) => CommandDef {
-            brief: "Clear the scrollback and viewport".into(),
+            brief: t("Clear the scrollback and viewport"),
             doc: "Removes all content from the screen and scrollback".into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
@@ -1211,7 +1217,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         Search(Pattern::CurrentSelectionOrEmptyString) => CommandDef {
-            brief: "Search".into(),
+            brief: t("Search"),
             doc: "Search in current pane".into(),
             keys: vec![(Modifiers::SUPER, "f".into())],
             args: &[ArgType::ActivePane],
@@ -1219,7 +1225,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         Search(_) => CommandDef {
-            brief: "Search pane output".into(),
+            brief: t("Search pane output"),
             doc: "Enters the search mode UI for the current pane".into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
@@ -1227,7 +1233,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ShowDebugOverlay => CommandDef {
-            brief: "Kaku Doctor".into(),
+            brief: t("Kaku Doctor"),
             doc: "Run kaku doctor in the current pane".into(),
             keys: vec![(Modifiers::CTRL.union(Modifiers::SHIFT), "l".into())],
             args: &[ArgType::ActiveWindow],
@@ -1235,7 +1241,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         InputSelector(_) => CommandDef {
-            brief: "Prompt the user to choose from a list".into(),
+            brief: t("Prompt the user to choose from a list"),
             doc: "Activates the selector overlay and wait for input".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1243,7 +1249,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         Confirmation(_) => CommandDef {
-            brief: "Prompt the user for confirmation".into(),
+            brief: t("Prompt the user for confirmation"),
             doc: "Activates the confirmation overlay and wait for input".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1251,7 +1257,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         PromptInputLine(_) => CommandDef {
-            brief: "Prompt the user for a line of text".into(),
+            brief: t("Prompt the user for a line of text"),
             doc: "Activates the prompt overlay and wait for input".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1259,7 +1265,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         QuickSelect => CommandDef {
-            brief: "QuickSelect".into(),
+            brief: t("QuickSelect"),
             doc: "Quick selection mode".into(),
             keys: vec![(Modifiers::CTRL.union(Modifiers::SHIFT), "Space".into())],
             args: &[ArgType::ActivePane],
@@ -1267,7 +1273,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         QuickSelectArgs(_) => CommandDef {
-            brief: "Enter QuickSelect mode".into(),
+            brief: t("Enter QuickSelect mode"),
             doc: "Activates the quick selection UI for the current pane".into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
@@ -1275,7 +1281,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         CharSelect(_) => CommandDef {
-            brief: "Enter Emoji / Character selection mode".into(),
+            brief: t("Enter Emoji / Character selection mode"),
             doc: "Activates the character selection UI for the current pane".into(),
             keys: vec![(Modifiers::CTRL.union(Modifiers::SHIFT), "u".into())],
             args: &[ArgType::ActivePane],
@@ -1286,7 +1292,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             mode: PaneSelectMode::Activate,
             ..
         }) => CommandDef {
-            brief: "Select Pane".into(),
+            brief: t("Select Pane"),
             doc: "Select a pane interactively".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::ALT), "p".into())],
             args: &[ArgType::ActivePane],
@@ -1297,7 +1303,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             mode: PaneSelectMode::SwapWithActive,
             ..
         }) => CommandDef {
-            brief: "Swap a pane with the active pane".into(),
+            brief: t("Swap a pane with the active pane"),
             doc: "Activates the pane selection UI".into(),
             keys: vec![], // FIXME: find a new assignment
             args: &[ArgType::ActivePane],
@@ -1308,7 +1314,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             mode: PaneSelectMode::SwapWithActiveKeepFocus,
             ..
         }) => CommandDef {
-            brief: "Swap a pane with the active pane, keeping focus".into(),
+            brief: t("Swap a pane with the active pane, keeping focus"),
             doc: "Activates the pane selection UI".into(),
             keys: vec![], // FIXME: find a new assignment
             args: &[ArgType::ActivePane],
@@ -1319,7 +1325,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             mode: PaneSelectMode::MoveToNewTab,
             ..
         }) => CommandDef {
-            brief: "Move Pane to New Tab".into(),
+            brief: t("Move Pane to New Tab"),
             doc: "Move selected pane to a new tab".into(),
             keys: vec![(
                 Modifiers::SUPER
@@ -1335,7 +1341,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             mode: PaneSelectMode::MoveToNewWindow,
             ..
         }) => CommandDef {
-            brief: "Move Pane to New Window".into(),
+            brief: t("Move Pane to New Window"),
             doc: "Move selected pane to a new window".into(),
             keys: vec![(
                 Modifiers::SUPER
@@ -1348,7 +1354,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         DecreaseFontSize => CommandDef {
-            brief: "Decrease Font Size".into(),
+            brief: t("Decrease Font Size"),
             doc: "Make text smaller".into(),
             keys: vec![
                 (Modifiers::SUPER, "-".into()),
@@ -1359,7 +1365,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         IncreaseFontSize => CommandDef {
-            brief: "Increase Font Size".into(),
+            brief: t("Increase Font Size"),
             doc: "Make text larger".into(),
             keys: vec![
                 (Modifiers::SUPER, "=".into()),
@@ -1370,7 +1376,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ResetFontSize => CommandDef {
-            brief: "Reset Font Size".into(),
+            brief: t("Reset Font Size"),
             doc: "Reset to configured font size".into(),
             keys: vec![
                 (Modifiers::SUPER, "0".into()),
@@ -1381,7 +1387,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ResetFontAndWindowSize => CommandDef {
-            brief: "Reset Window & Font Size".into(),
+            brief: t("Reset Window & Font Size"),
             doc: "Reset window and font to defaults".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1389,7 +1395,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         SpawnTab(SpawnTabDomain::CurrentPaneDomain) => CommandDef {
-            brief: "New Tab".into(),
+            brief: t("New Tab"),
             doc: "Open a new tab".into(),
             keys: vec![(Modifiers::SUPER, "t".into())],
             args: &[ArgType::ActiveWindow],
@@ -1397,7 +1403,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         SpawnTab(SpawnTabDomain::DefaultDomain) => CommandDef {
-            brief: "New Tab".into(),
+            brief: t("New Tab"),
             doc: "New tab in default domain".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1441,7 +1447,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivateTab(-1) => CommandDef {
-            brief: "Activate right-most tab".into(),
+            brief: t("Activate right-most tab"),
             doc: "Activates the tab on the far right".into(),
             keys: vec![(Modifiers::SUPER, "9".into())],
             args: &[ArgType::ActiveWindow],
@@ -1508,7 +1514,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
         EmitEvent(name) => {
             if name == "run-kaku-ai-config" {
                 CommandDef {
-                    brief: "AI Config".into(),
+                    brief: t("AI Config"),
                     doc: "Open AI configuration".into(),
                     keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "a".into())],
                     args: &[ArgType::ActiveWindow],
@@ -1526,7 +1532,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
                 }
             } else if name == "kaku-launch-lazygit" {
                 CommandDef {
-                    brief: "Lazygit".into(),
+                    brief: t("Lazygit"),
                     doc: "Open lazygit".into(),
                     keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "g".into())],
                     args: &[ArgType::ActiveWindow],
@@ -1535,7 +1541,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
                 }
             } else if name == "kaku-launch-yazi" {
                 CommandDef {
-                    brief: "Yazi File Manager".into(),
+                    brief: t("Yazi File Manager"),
                     doc: "Open Yazi file manager".into(),
                     keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "y".into())],
                     args: &[ArgType::ActiveWindow],
@@ -1544,7 +1550,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
                 }
             } else if name == "kaku-open-remote-files" {
                 CommandDef {
-                    brief: "Remote Files".into(),
+                    brief: t("Remote Files"),
                     doc: "Open the current SSH domain in a local Yazi tab".into(),
                     keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "r".into())],
                     args: &[ArgType::ActiveWindow],
@@ -1567,7 +1573,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             }
         }
         CloseCurrentTab { confirm: true } => CommandDef {
-            brief: "Close Tab".into(),
+            brief: t("Close Tab"),
             doc: "Close current tab, prompting first if needed".into(),
             keys: vec![],
             args: &[ArgType::ActiveTab],
@@ -1575,7 +1581,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         CloseCurrentTab { confirm: false } => CommandDef {
-            brief: "Close Tab".into(),
+            brief: t("Close Tab"),
             doc: "Close current tab".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "w".into())],
             args: &[ArgType::ActiveTab],
@@ -1583,7 +1589,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         CloseCurrentPane { confirm: true } => CommandDef {
-            brief: "Close Pane".into(),
+            brief: t("Close Pane"),
             doc: "Close current pane, prompting first if needed".into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
@@ -1591,7 +1597,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         CloseCurrentPane { confirm: false } => CommandDef {
-            brief: "Close Pane".into(),
+            brief: t("Close Pane"),
             doc: "Close current pane".into(),
             keys: vec![(Modifiers::SUPER, "w".into())],
             args: &[ArgType::ActivePane],
@@ -1599,7 +1605,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ReopenLastClosedTab => CommandDef {
-            brief: "Reopen Last Closed Tab".into(),
+            brief: t("Reopen Last Closed Tab"),
             doc: "Reopens the most recently closed tab, restoring its working directory.".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "t".into())],
             args: &[ArgType::ActiveWindow],
@@ -1619,7 +1625,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             }
         }
         ActivateWindowRelative(-1) => CommandDef {
-            brief: "Previous Window".into(),
+            brief: t("Previous Window"),
             doc: "Switch to previous window".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "`".into())],
             args: &[ArgType::ActiveWindow],
@@ -1627,7 +1633,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivateWindowRelative(1) => CommandDef {
-            brief: "Next Window".into(),
+            brief: t("Next Window"),
             doc: "Switch to next window".into(),
             keys: vec![(Modifiers::SUPER, "`".into())],
             args: &[ArgType::ActiveWindow],
@@ -1655,7 +1661,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             }
         }
         ActivateWindowRelativeNoWrap(-1) => CommandDef {
-            brief: "Previous Window (No Wrap)".into(),
+            brief: t("Previous Window (No Wrap)"),
             doc: "Switch to previous window".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1663,7 +1669,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivateWindowRelativeNoWrap(1) => CommandDef {
-            brief: "Next Window (No Wrap)".into(),
+            brief: t("Next Window (No Wrap)"),
             doc: "Switch to next window".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1687,7 +1693,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             }
         }
         ActivateTabRelative(-1) => CommandDef {
-            brief: "Previous Tab".into(),
+            brief: t("Previous Tab"),
             doc: "Switch to previous tab".into(),
             keys: vec![
                 (Modifiers::SUPER.union(Modifiers::SHIFT), "[".into()),
@@ -1699,7 +1705,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivateTabRelative(1) => CommandDef {
-            brief: "Next Tab".into(),
+            brief: t("Next Tab"),
             doc: "Switch to next tab".into(),
             keys: vec![
                 (Modifiers::SUPER.union(Modifiers::SHIFT), "]".into()),
@@ -1727,7 +1733,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             }
         }
         ActivateTabRelativeNoWrap(-1) => CommandDef {
-            brief: "Activate the tab to the left (no wrapping)".into(),
+            brief: t("Activate the tab to the left (no wrapping)"),
             doc: "Activates the tab to the left. Stopping at the left-most tab".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1735,7 +1741,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivateTabRelativeNoWrap(1) => CommandDef {
-            brief: "Activate the tab to the right (no wrapping)".into(),
+            brief: t("Activate the tab to the right (no wrapping)"),
             doc: "Activates the tab to the right. Stopping at the right-most tab".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -1755,7 +1761,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             }
         }
         ReloadConfiguration => CommandDef {
-            brief: "Reload configuration (disabled)".into(),
+            brief: t("Reload configuration (disabled)"),
             doc: "Manual reload is disabled; configuration changes are reloaded automatically."
                 .into(),
             keys: vec![],
@@ -1764,7 +1770,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         QuitApplication => CommandDef {
-            brief: "Quit Kaku".into(),
+            brief: t("Quit Kaku"),
             doc: "Quits Kaku".into(),
             keys: vec![(Modifiers::SUPER, "q".into())],
             args: &[],
@@ -1772,7 +1778,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         MoveTabRelative(-1) => CommandDef {
-            brief: "Move Tab Left".into(),
+            brief: t("Move Tab Left"),
             doc: "Move current tab left".into(),
             keys: vec![(Modifiers::CTRL.union(Modifiers::SHIFT), "PageUp".into())],
             args: &[ArgType::ActiveTab],
@@ -1780,7 +1786,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         MoveTabRelative(1) => CommandDef {
-            brief: "Move Tab Right".into(),
+            brief: t("Move Tab Right"),
             doc: "Move current tab right".into(),
             keys: vec![(Modifiers::CTRL.union(Modifiers::SHIFT), "PageDown".into())],
             args: &[ArgType::ActiveTab],
@@ -1826,7 +1832,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             let amount = amount.into_inner();
             if amount == -1.0 {
                 CommandDef {
-                    brief: "Scroll Up One Page".into(),
+                    brief: t("Scroll Up One Page"),
                     doc: "Scrolls the viewport up by 1 page".into(),
                     keys: vec![(Modifiers::SHIFT, "PageUp".into())],
                     args: &[ArgType::ActivePane],
@@ -1835,7 +1841,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
                 }
             } else if amount == 1.0 {
                 CommandDef {
-                    brief: "Scroll Down One Page".into(),
+                    brief: t("Scroll Down One Page"),
                     doc: "Scrolls the viewport down by 1 page".into(),
                     keys: vec![(Modifiers::SHIFT, "PageDown".into())],
                     args: &[ArgType::ActivePane],
@@ -1911,7 +1917,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ScrollToBottom => CommandDef {
-            brief: "Scroll to Bottom".into(),
+            brief: t("Scroll to Bottom"),
             doc: "Scroll to bottom of output".into(),
             keys: vec![(Modifiers::SUPER, "End".into())],
             args: &[ArgType::ActivePane],
@@ -1919,7 +1925,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ScrollToTop => CommandDef {
-            brief: "Scroll to Top".into(),
+            brief: t("Scroll to Top"),
             doc: "Scroll to top of output".into(),
             keys: vec![(Modifiers::SUPER, "Home".into())],
             args: &[ArgType::ActivePane],
@@ -1927,7 +1933,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivateCopyMode => CommandDef {
-            brief: "Activate Copy Mode".into(),
+            brief: t("Activate Copy Mode"),
             doc: "Enter mouse-less copy mode to select text using only \
             the keyboard"
                 .into(),
@@ -1940,7 +1946,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             domain: SpawnTabDomain::CurrentPaneDomain,
             ..
         }) => CommandDef {
-            brief: label_string(action, "Split Pane Top/Bottom".to_string()).into(),
+            brief: label_string(action, t("Split Pane Top/Bottom").into_owned()).into(),
             doc: "Split pane horizontally".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "d".into())],
             args: &[ArgType::ActivePane],
@@ -1951,7 +1957,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             domain: SpawnTabDomain::CurrentPaneDomain,
             ..
         }) => CommandDef {
-            brief: label_string(action, "Split Pane Left/Right".to_string()).into(),
+            brief: label_string(action, t("Split Pane Left/Right").into_owned()).into(),
             doc: "Split pane vertically".into(),
             keys: vec![(Modifiers::SUPER, "d".into())],
             args: &[ArgType::ActivePane],
@@ -1979,7 +1985,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         AdjustPaneSize(PaneDirection::Left, amount) => CommandDef {
-            brief: "Resize Split Left".into(),
+            brief: t("Resize Split Left"),
             doc: format!("Move the current split divider left (step: {amount} cells)").into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::CTRL), "LeftArrow".into())],
             args: &[ArgType::ActivePane],
@@ -1987,7 +1993,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         AdjustPaneSize(PaneDirection::Right, amount) => CommandDef {
-            brief: "Resize Split Right".into(),
+            brief: t("Resize Split Right"),
             doc: format!("Move the current split divider right (step: {amount} cells)").into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::CTRL), "RightArrow".into())],
             args: &[ArgType::ActivePane],
@@ -1995,7 +2001,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         AdjustPaneSize(PaneDirection::Up, amount) => CommandDef {
-            brief: "Resize Split Up".into(),
+            brief: t("Resize Split Up"),
             doc: format!("Move the current split divider up (step: {amount} cells)").into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::CTRL), "UpArrow".into())],
             args: &[ArgType::ActivePane],
@@ -2003,7 +2009,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         AdjustPaneSize(PaneDirection::Down, amount) => CommandDef {
-            brief: "Resize Split Down".into(),
+            brief: t("Resize Split Down"),
             doc: format!("Move the current split divider down (step: {amount} cells)").into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::CTRL), "DownArrow".into())],
             args: &[ArgType::ActivePane],
@@ -2013,7 +2019,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
         AdjustPaneSize(PaneDirection::Next | PaneDirection::Prev, _) => return None,
         ActivatePaneDirection(PaneDirection::Next | PaneDirection::Prev) => return None,
         ActivatePaneDirection(PaneDirection::Left) => CommandDef {
-            brief: "Activate Pane Left".into(),
+            brief: t("Activate Pane Left"),
             doc: "Activates the pane to the left of the current pane".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::ALT), "LeftArrow".into())],
             args: &[ArgType::ActivePane],
@@ -2021,7 +2027,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivatePaneDirection(PaneDirection::Right) => CommandDef {
-            brief: "Activate Pane Right".into(),
+            brief: t("Activate Pane Right"),
             doc: "Activates the pane to the right of the current pane".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::ALT), "RightArrow".into())],
             args: &[ArgType::ActivePane],
@@ -2029,7 +2035,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivatePaneDirection(PaneDirection::Up) => CommandDef {
-            brief: "Activate Pane Up".into(),
+            brief: t("Activate Pane Up"),
             doc: "Activates the pane to the top of the current pane".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::ALT), "UpArrow".into())],
             args: &[ArgType::ActivePane],
@@ -2037,7 +2043,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivatePaneDirection(PaneDirection::Down) => CommandDef {
-            brief: "Activate Pane Down".into(),
+            brief: t("Activate Pane Down"),
             doc: "Activates the pane to the bottom of the current pane".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::ALT), "DownArrow".into())],
             args: &[ArgType::ActivePane],
@@ -2045,7 +2051,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         TogglePaneZoomState => CommandDef {
-            brief: "Zoom Pane".into(),
+            brief: t("Zoom Pane"),
             doc: "Toggle pane zoom".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "Enter".into())],
             args: &[ArgType::ActivePane],
@@ -2053,7 +2059,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivateLastTab => CommandDef {
-            brief: "Last Active Tab".into(),
+            brief: t("Last Active Tab"),
             doc: "Switch to last active tab".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "t".into())],
             args: &[ArgType::ActiveWindow],
@@ -2061,7 +2067,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ClearKeyTableStack => CommandDef {
-            brief: "Clear the key table stack".into(),
+            brief: t("Clear the key table stack"),
             doc: "Removes all entries from the stack".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -2069,7 +2075,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         OpenLinkAtMouseCursor => CommandDef {
-            brief: "Open link at mouse cursor".into(),
+            brief: t("Open link at mouse cursor"),
             doc: "If there is no link under the mouse cursor, has no effect.".into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
@@ -2077,7 +2083,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ShowLauncherArgs(_) | ShowLauncher => CommandDef {
-            brief: "Launcher".into(),
+            brief: t("Launcher"),
             doc: "Open command launcher".into(),
             keys: vec![],
             args: &[ArgType::ActiveWindow],
@@ -2085,7 +2091,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ShowTabNavigator => CommandDef {
-            brief: "Tab Navigator".into(),
+            brief: t("Tab Navigator"),
             doc: "Interactive tab switcher".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "o".into())],
             args: &[ArgType::ActiveWindow],
@@ -2093,7 +2099,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         DetachDomain(SpawnTabDomain::CurrentPaneDomain) => CommandDef {
-            brief: "Detach the domain of the active pane".into(),
+            brief: t("Detach the domain of the active pane"),
             doc: "Detaches (disconnects from) the domain of the active pane".into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
@@ -2101,7 +2107,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         DetachDomain(SpawnTabDomain::DefaultDomain) => CommandDef {
-            brief: "Detach the default domain".into(),
+            brief: t("Detach the default domain"),
             doc: "Detaches (disconnects from) the default domain".into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
@@ -2126,7 +2132,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
         },
         OpenUri(uri) => match uri.as_ref() {
             "https://github.com/tw93/Kaku" => CommandDef {
-                brief: "Star on GitHub".into(),
+                brief: t("Star on GitHub"),
                 doc: "Star Kaku on GitHub".into(),
                 keys: vec![],
                 args: &[],
@@ -2134,7 +2140,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
                 icon: None,
             },
             "https://github.com/tw93/Kaku/discussions/" => CommandDef {
-                brief: "Discuss on GitHub".into(),
+                brief: t("Discuss on GitHub"),
                 doc: "Visit Kaku's GitHub discussion".into(),
                 keys: vec![],
                 args: &[],
@@ -2142,7 +2148,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
                 icon: None,
             },
             "https://github.com/tw93/Kaku/issues/" => CommandDef {
-                brief: "Report Issue".into(),
+                brief: t("Report Issue"),
                 doc: "Submit bug report or feature request".into(),
                 keys: vec![],
                 args: &[],
@@ -2191,7 +2197,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         Nop => CommandDef {
-            brief: "Does nothing".into(),
+            brief: t("Does nothing"),
             doc: "Has no effect".into(),
             keys: vec![],
             args: &[],
@@ -2401,7 +2407,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         PopKeyTable => CommandDef {
-            brief: "Pop the current key table".into(),
+            brief: t("Pop the current key table"),
             doc: "Pop the current key table".into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
@@ -2433,7 +2439,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         TogglePaneSplitDirection => CommandDef {
-            brief: "Toggle Split Direction".into(),
+            brief: t("Toggle Split Direction"),
             doc: "Toggle the split direction between horizontal and vertical".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "s".into())],
             args: &[ArgType::ActivePane],
@@ -2456,7 +2462,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             }
         }
         ResetTerminal => CommandDef {
-            brief: "Reset the terminal emulation state in the current pane".into(),
+            brief: t("Reset the terminal emulation state in the current pane"),
             doc: "Reset the terminal emulation state in the current pane".into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
@@ -2464,7 +2470,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: None,
         },
         ActivateCommandPalette => CommandDef {
-            brief: "Command Palette".into(),
+            brief: t("Command Palette"),
             doc: "Open command palette".into(),
             keys: vec![(Modifiers::SUPER.union(Modifiers::SHIFT), "p".into())],
             args: &[ArgType::ActivePane],

--- a/kaku-gui/src/overlay/launcher.rs
+++ b/kaku-gui/src/overlay/launcher.rs
@@ -11,6 +11,7 @@ use crate::overlay::quickselect;
 use crate::overlay::selector::{matcher_pattern, matcher_score};
 use crate::termwindow::TermWindowNotif;
 use config::configuration;
+use config::i18n::{t, t_display};
 use config::keyassignment::KeyAssignment::SetPaneEncoding;
 use config::keyassignment::{
     KeyAssignment, LauncherActionArgs, PaneEncoding, SpawnCommand, SpawnTabDomain,
@@ -138,9 +139,9 @@ impl LauncherArgs {
                 let name = dom.domain_name();
                 let label = dom.domain_label().await;
                 let label = if name == label || label.is_empty() {
-                    format!("domain `{}`", name)
+                    format!("{} `{}`", t("domain"), name)
                 } else {
-                    format!("domain `{}` - {}", name, label)
+                    format!("{} `{}` - {}", t("domain"), name, label)
                 };
                 d.push(LauncherDomainEntry {
                     domain_id: dom.domain_id(),
@@ -240,6 +241,21 @@ impl LauncherState {
     fn build_entries(&mut self, args: LauncherArgs) {
         let config = configuration();
 
+        // Add a single "Pane Encoding" submenu entry as the very first item
+        // Only when NOT already viewing the encoding submenu
+        if !args.flags.contains(LauncherFlags::PANE_ENCODINGS) {
+            self.entries.push(Entry {
+                label: t_display("Pane Encoding"),
+                action: KeyAssignment::ShowLauncherArgs(LauncherActionArgs {
+                    flags: LauncherFlags::PANE_ENCODINGS,
+                    title: Some(t_display("Pane Encoding")),
+                    help_text: None,
+                    fuzzy_help_text: None,
+                    alphabet: None,
+                }),
+            });
+        }
+
         // Pull in the user defined entries from the launch_menu
         // section of the configuration.
         if args.flags.contains(LauncherFlags::LAUNCH_MENU_ITEMS) {
@@ -249,7 +265,7 @@ impl LauncherState {
                         Some(label) => label.to_string(),
                         None => match item.args.as_ref() {
                             Some(args) => args.join(" "),
-                            None => "(default shell)".to_string(),
+                            None => t_display("(default shell)"),
                         },
                     },
                     action: KeyAssignment::SpawnCommandInNewTab(item.clone()),
@@ -260,7 +276,7 @@ impl LauncherState {
         for domain in &args.domains {
             let entry = if domain.state == DomainState::Attached {
                 Entry {
-                    label: format!("New Tab ({})", domain.label),
+                    label: format!("{} ({})", t("New Tab"), domain.label),
                     action: KeyAssignment::SpawnCommandInNewTab(SpawnCommand {
                         domain: SpawnTabDomain::DomainName(domain.name.to_string()),
                         ..SpawnCommand::default()
@@ -268,7 +284,7 @@ impl LauncherState {
                 }
             } else {
                 Entry {
-                    label: format!("Attach {}", domain.label),
+                    label: format!("{} {}", t("Attach"), domain.label),
                     action: KeyAssignment::AttachDomain(domain.name.to_string()),
                 }
             };
@@ -286,7 +302,7 @@ impl LauncherState {
             for ws in &args.workspaces {
                 if *ws != args.active_workspace {
                     self.entries.push(Entry {
-                        label: format!("Switch to workspace: `{}`", ws),
+                        label: format!("{}: `{}`", t("Switch to workspace"), ws),
                         action: KeyAssignment::SwitchToWorkspace {
                             name: Some(ws.clone()),
                             spawn: None,
@@ -296,7 +312,9 @@ impl LauncherState {
             }
             self.entries.push(Entry {
                 label: format!(
-                    "Create new Workspace (current is `{}`)",
+                    "{} ({}: `{}`)",
+                    t("Create new Workspace"),
+                    t("current is"),
                     args.active_workspace
                 ),
                 action: KeyAssignment::SwitchToWorkspace {
@@ -316,7 +334,7 @@ impl LauncherState {
         if args.flags.contains(LauncherFlags::PANE_ENCODINGS) {
             for encoding in PaneEncoding::ordered_list() {
                 self.entries.push(Entry {
-                    label: format!("Set pane encoding to {encoding}"),
+                    label: format!("{} {encoding}", t("Set pane encoding to")),
                     action: SetPaneEncoding(encoding),
                 });
             }
@@ -598,12 +616,12 @@ impl LauncherState {
         self.entries.clear();
         for encoding in PaneEncoding::ordered_list() {
             self.entries.push(Entry {
-                label: format!("Set pane encoding to {encoding}"),
+                label: format!("{} {encoding}", t("Set pane encoding to")),
                 action: SetPaneEncoding(encoding),
             });
         }
         self.help_text =
-            "Select encoding  |  Enter = set  |  Esc = back  |  / = filter".to_string();
+            t("Select encoding  |  Enter = set  |  Esc = back  |  / = filter").into_owned();
         self.active_idx = 0;
         self.top_row = 0;
         self.filtering = false;

--- a/kaku/Cargo.toml
+++ b/kaku/Cargo.toml
@@ -35,6 +35,7 @@ termwiz-funcs.workspace = true
 termwiz.workspace = true
 toml.workspace = true
 umask.workspace = true
+unicode-width.workspace = true
 url.workspace = true
 wezterm-client.workspace = true
 wezterm-gui-subcommands.workspace = true

--- a/kaku/src/config_tui/mod.rs
+++ b/kaku/src/config_tui/mod.rs
@@ -3,6 +3,7 @@ mod ui;
 use crate::assistant_config;
 use crate::utils::open_path_in_editor;
 use anyhow::Context;
+use config::i18n::{self, Language};
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -356,6 +357,15 @@ impl App {
                 options: vec!["On", "Off"],
                 skip_write: false,
             },
+            ConfigField {
+                section: "Appearance",
+                key: "Language",
+                lua_key: "language",
+                value: String::new(),
+                default: "English".into(),
+                options: vec!["English", "中文"],
+                skip_write: false,
+            },
         ];
 
         Self {
@@ -413,6 +423,21 @@ impl App {
                     }
                 }
             }
+        }
+
+        // Sync i18n language so the TUI itself renders in the chosen language.
+        if let Some(field) = self.fields.iter().find(|f| f.lua_key == "language") {
+            let display = if field.value.is_empty() {
+                &field.default
+            } else {
+                &field.value
+            };
+            let lang = if display == "中文" {
+                Language::Zh
+            } else {
+                Language::En
+            };
+            i18n::set_language(lang);
         }
     }
 
@@ -670,6 +695,13 @@ impl App {
                     None
                 }
             }
+            "language" => {
+                let value = raw.trim().trim_matches('\'').trim_matches('"');
+                match value.to_lowercase().as_str() {
+                    "zh" | "chinese" | "中文" => Some("中文".into()),
+                    _ => Some("English".into()),
+                }
+            }
             "macos_global_hotkey" => {
                 let value = raw.trim();
                 if value.eq_ignore_ascii_case("nil") {
@@ -755,6 +787,7 @@ impl App {
                 self.fields[self.selected].value = next_value;
                 self.fields[self.selected].skip_write = false;
                 self.dirty = true;
+                self.sync_language_if_changed();
             } else {
                 self.mode = Mode::Selecting;
                 let current = self.display_value(field);
@@ -828,6 +861,23 @@ impl App {
         self.fields[self.selected].skip_write = false;
         self.mode = Mode::Normal;
         self.dirty = true;
+        self.sync_language_if_changed();
+    }
+
+    fn sync_language_if_changed(&self) {
+        if let Some(field) = self.fields.iter().find(|f| f.lua_key == "language") {
+            let display = if field.value.is_empty() {
+                &field.default
+            } else {
+                &field.value
+            };
+            let lang = if display == "中文" {
+                Language::Zh
+            } else {
+                Language::En
+            };
+            i18n::set_language(lang);
+        }
     }
 
     fn edit_backspace(&mut self) {
@@ -945,7 +995,7 @@ impl App {
     fn always_write_field(lua_key: &str) -> bool {
         // Keep theme and tab bar position explicit so switching back to the
         // bundled defaults does not rely on downstream fallback behavior.
-        matches!(lua_key, "color_scheme" | "tab_bar_at_bottom")
+        matches!(lua_key, "color_scheme" | "tab_bar_at_bottom" | "language")
     }
 
     fn remove_lua_config(&self, content: &str, lua_key: &str) -> String {
@@ -1149,6 +1199,13 @@ impl App {
                 } else {
                     // confirm_edit() already validated; nil is a defensive fallback.
                     Self::hotkey_to_lua(&field.value).unwrap_or_else(|| "nil".into())
+                }
+            }
+            "language" => {
+                if field.value == "中文" {
+                    "'zh'".into()
+                } else {
+                    "'en'".into()
                 }
             }
             _ => format!("'{}'", field.value),

--- a/kaku/src/config_tui/ui.rs
+++ b/kaku/src/config_tui/ui.rs
@@ -2,9 +2,11 @@ use ratatui::layout::{Constraint, Layout, Margin, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+use unicode_width::UnicodeWidthStr;
 
 use super::{App, Mode};
 use crate::tui_core::theme::{accent, bg, muted, panel, primary, text_fg};
+use config::i18n::{t, t_display};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum MainLayoutMode {
@@ -113,7 +115,7 @@ fn render_header(frame: &mut ratatui::Frame, area: Rect) {
             Style::default().fg(primary()).add_modifier(Modifier::BOLD),
         ),
         Span::styled(" · ", Style::default().fg(muted())),
-        Span::styled("Settings", Style::default().fg(text_fg())),
+        Span::styled(t("Settings").into_owned(), Style::default().fg(text_fg())),
     ]);
     frame.render_widget(Paragraph::new(vec![line, Line::from("")]), area);
 }
@@ -149,8 +151,14 @@ fn render_fields(frame: &mut ratatui::Frame, area: Rect, app: &App) {
             selected_flat = Some(flat);
         }
 
-        let display_value = app.display_value(field);
+        let display_value = t_display(app.display_value(field));
         let has_options = field.has_options();
+        let translated_key = t_display(field.key);
+        let padded_key = {
+            let w = UnicodeWidthStr::width(translated_key.as_str());
+            let pad = key_width.saturating_sub(w);
+            format!("{}{}", translated_key, " ".repeat(pad))
+        };
 
         let key_style = if is_selected {
             Style::default().fg(primary()).add_modifier(Modifier::BOLD)
@@ -186,7 +194,7 @@ fn render_fields(frame: &mut ratatui::Frame, area: Rect, app: &App) {
                     }),
             ),
             Span::styled(
-                format!("{:<width$}", field.key, width = key_width),
+                padded_key,
                 key_style,
             ),
             Span::styled(format!("{}{}", display_value, suffix), value_style),
@@ -195,6 +203,23 @@ fn render_fields(frame: &mut ratatui::Frame, area: Rect, app: &App) {
         items.push(ListItem::new(line));
         flat += 1;
     }
+
+    items.push(ListItem::new(Line::from("")));
+    items.push(ListItem::new(Line::from(vec![
+        Span::styled("    ", Style::default()),
+        Span::styled("ESC", Style::default().fg(primary())),
+        Span::styled(
+            format!(" {}", t("save and apply changes")),
+            Style::default().fg(muted()),
+        ),
+        Span::styled("  ·  ", Style::default().fg(muted())),
+        Span::styled("E", Style::default().fg(primary())),
+        Span::styled(
+            format!(" {}", t("open full config")),
+            Style::default().fg(muted()),
+        ),
+    ])));
+
 
     let mut state = ListState::default();
     state.select(selected_flat);
@@ -263,8 +288,11 @@ fn render_selector(frame: &mut ratatui::Frame, area: Rect, app: &App) {
 
     let block = Block::default()
         .title(Line::from(vec![
-            Span::styled(" Select: ", Style::default().fg(primary())),
-            Span::styled(field.key, Style::default().fg(text_fg())),
+            Span::styled(
+                t(" Select: ").into_owned(),
+                Style::default().fg(primary()),
+            ),
+            Span::styled(t_display(field.key), Style::default().fg(text_fg())),
             Span::raw(" "),
         ]))
         .borders(Borders::ALL)
@@ -281,6 +309,7 @@ fn render_selector(frame: &mut ratatui::Frame, area: Rect, app: &App) {
         .map(|(i, opt)| {
             let is_sel = i == select_index;
             let marker = if is_sel { "› " } else { "  " };
+            let translated_opt = t_display(opt);
             let style = if is_sel {
                 Style::default().fg(primary()).add_modifier(Modifier::BOLD)
             } else {
@@ -297,7 +326,7 @@ fn render_selector(frame: &mut ratatui::Frame, area: Rect, app: &App) {
                             Modifier::empty()
                         }),
                 ),
-                Span::styled(*opt, style),
+                Span::styled(translated_opt, style),
             ]))
         })
         .collect();
@@ -327,13 +356,22 @@ fn render_editor(frame: &mut ratatui::Frame, area: Rect, app: &App) {
 
     let block = Block::default()
         .title(Line::from(vec![
-            Span::styled(" Edit: ", Style::default().fg(primary())),
-            Span::styled(field.key, Style::default().fg(text_fg())),
+            Span::styled(
+                t(" Edit: ").into_owned(),
+                Style::default().fg(primary()),
+            ),
+            Span::styled(t_display(field.key), Style::default().fg(text_fg())),
             Span::styled("  ", Style::default()),
             Span::styled("Enter", Style::default().fg(primary())),
-            Span::styled(": Save  ", Style::default().fg(muted())),
+            Span::styled(
+                t(": Save  ").into_owned(),
+                Style::default().fg(muted()),
+            ),
             Span::styled("Esc", Style::default().fg(primary())),
-            Span::styled(": Cancel ", Style::default().fg(muted())),
+            Span::styled(
+                t(": Cancel ").into_owned(),
+                Style::default().fg(muted()),
+            ),
         ]))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(primary()))


### PR DESCRIPTION
## Summary

Add bilingual (English / Chinese) UI support to Kaku, controlled by a new `language` config option.

### What's included

**i18n infrastructure** (`config/src/i18n.rs`)
- Lightweight translation layer using a `lazy_static` HashMap
- `t()` / `t_display()` helpers return `Cow<'static, str>` for zero-cost English path
- Supports `"en"` (default) and `"zh"`

**Config integration**
- New `language: Option<String>` field in `Config` struct
- Language is applied on both startup and live config reload
- Persist explicit `color_scheme` selection when changed in Settings TUI

**Translated surfaces**
- Command palette: 60+ command labels wrapped with `t()`
- Launcher overlay: domain/workspace/encoding entries
- Settings TUI: all field labels, section chrome, and footer hints
- Added `unicode-width` dep for correct CJK column alignment in the TUI

### Usage

```lua
-- ~/.config/kaku/kaku.lua
config.language = "zh"   -- Chinese UI
config.language = "en"   -- English UI (default)
```

Or change it in **Settings TUI → Language**.

## Changed Files

| File | Change |
|------|--------|
| `config/src/i18n.rs` | **New** — translation map & helpers |
| `config/src/config.rs` | Add `language` field |
| `config/src/lib.rs` | Register module, init on config load |
| `kaku-gui/src/commands.rs` | Wrap command labels with `t()` |
| `kaku-gui/src/overlay/launcher.rs` | Wrap launcher strings with `t()` |
| `kaku/src/config_tui/mod.rs` | Add Language setting row |
| `kaku/src/config_tui/ui.rs` | Translate Settings TUI chrome |
| `Cargo.toml` / `kaku/Cargo.toml` | Add `unicode-width` dependency |

## Test Plan

- [x] `cargo check` passes
- [x] Settings TUI → change Language to 中文 → all labels switch
- [x] Command Palette shows translated entries in Chinese mode
- [x] `config.language = "zh"` in kaku.lua → Chinese UI on restart
- [x] English remains default when `language` is unset