### PR TITLE
fix(macos): open files with OS default app before text editor fallback

### DIFF
--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -4379,11 +4379,11 @@ impl TermWindow {
 
         #[cfg(target_os = "macos")]
         {
-            if target.path.is_file() && Self::try_open_text(&target.path)? {
+            if Self::try_open_path_with_default_app(&target.path)? {
                 return Ok(());
             }
 
-            if Self::try_open_path_with_default_app(&target.path)? {
+            if target.path.is_file() && Self::try_open_text(&target.path)? {
                 return Ok(());
             }
 


### PR DESCRIPTION
## Summary
- When clicking a file path hyperlink in the terminal, macOS `open -t` (text editor) was tried **before** `open` (default app), causing files like `.md` to always open in TextEdit instead of the user's preferred app (e.g. Typora, Marked)
- Swapped the order so `try_open_path_with_default_app` runs first, falling back to `try_open_text` only if the default app fails

## Test plan
- [ ] Click a `.md` file hyperlink — should open in the OS default Markdown viewer
- [ ] Click a `.pdf` file hyperlink — should open in Preview (or configured default)
- [ ] Click a file with no default association — should fall back to text editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)