### PR TITLE
fix: remove existing ssh alias before defining ssh function

### DIFF
--- a/assets/shell-integration/kaku.sh
+++ b/assets/shell-integration/kaku.sh
@@ -44,6 +44,10 @@ esac
 # Set KAKU_SSH_SKIP_TERM_FIX=1 to disable. If the user already defined ssh(),
 # keep their function untouched.
 if ! typeset -f ssh >/dev/null 2>&1; then
+    # Remove any existing alias to allow function definition
+    if alias ssh > /dev/null 2>&1; then
+        unalias ssh
+    fi
   ssh() {
     if [[ -z "${KAKU_SSH_SKIP_TERM_FIX-}" && "${TERM:-}" == "kaku" ]]; then
       TERM=xterm-256color command ssh "$@"

--- a/assets/shell-integration/setup_zsh.sh
+++ b/assets/shell-integration/setup_zsh.sh
@@ -1249,6 +1249,10 @@ fi
 # Guard: only define if no existing ssh function is present, so user-defined
 # wrappers (e.g. from fzf-ssh, autossh plugins) are not silently replaced.
 if ! typeset -f ssh > /dev/null 2>&1; then
+    # Remove any existing alias to allow function definition
+    if alias ssh > /dev/null 2>&1; then
+        unalias ssh
+    fi
 ssh() {
     local -a extra_opts=()
 


### PR DESCRIPTION
When users have 'alias ssh' defined in their .zshrc (e.g., for trzsz), the kaku ssh function definition fails with error:
  'defining function based on alias ssh'

This fix adds alias detection and removal before defining the function, allowing kaku to work correctly even when users have ssh aliases.