### PR TITLE
feat: ignore SIGPIPE exit code 141 in AI assistant

### DIFF
--- a/assets/macos/Kaku.app/Contents/Resources/kaku.lua
+++ b/assets/macos/Kaku.app/Contents/Resources/kaku.lua
@@ -2725,6 +2725,10 @@ wezterm.on('user-var-changed', function(window, pane, name, value)
     ai_debug_log("user-var-changed ignored exit_code=130")
     return
   end
+  if exit_code == 141 then
+    ai_debug_log("user-var-changed ignored exit_code=141")
+    return
+  end
 
   local pane_id_ok, pane_id_value = pcall(function()
     return pane:pane_id()


### PR DESCRIPTION
### Problem
Currently, when a user runs a command that pipes output to a pager (like `git log` which defaults to `less`), and exits the pager early by pressing `q`, the pager closes its end of the pipe. The originating process (`git` in this case) then receives a `SIGPIPE` signal and terminates with exit code `141` (`128 + 13`). 

Because Kaku Assistant monitors non-zero exit codes to trigger AI suggestions, it incorrectly interprets this `141` exit code as a command failure and pops up a suggestion, which is annoying and unnecessary for standard pager interactions.

### Solution
This PR adds exit code `141` (SIGPIPE) to the ignore list in the Kaku Assistant evaluation logic (alongside `130` for SIGINT/Ctrl+C). This ensures that expected broken pipe errors caused by user interactions (like exiting a pager or piping to `head` / `grep -q`) do not trigger false positive AI suggestions.