### PR TITLE
fix(gui): require Command key to open links (#212)

### DIFF
--- a/kaku-gui/src/inputmap.rs
+++ b/kaku-gui/src/inputmap.rs
@@ -181,7 +181,7 @@ impl InputMap {
                         streak: 1,
                         button: MouseButton::Left
                     },
-                    CompleteSelectionOrOpenLinkAtMouseCursor(
+                    CompleteSelection(
                         ClipboardCopyDestination::ClipboardAndPrimarySelection
                     )
                 ],
@@ -195,9 +195,21 @@ impl InputMap {
                         streak: 1,
                         button: MouseButton::Left
                     },
-                    CompleteSelectionOrOpenLinkAtMouseCursor(
+                    CompleteSelection(
                         ClipboardCopyDestination::ClipboardAndPrimarySelection
                     )
+                ],
+                [
+                    MouseEventTriggerMods {
+                        mods: Modifiers::SUPER,
+                        mouse_reporting: false,
+                        alt_screen: MouseEventAltScreen::Any,
+                    },
+                    MouseEventTrigger::Up {
+                        streak: 1,
+                        button: MouseButton::Left
+                    },
+                    OpenLinkAtMouseCursor
                 ],
                 [
                     MouseEventTriggerMods {
@@ -233,7 +245,7 @@ impl InputMap {
                         streak: 1,
                         button: MouseButton::Left
                     },
-                    CompleteSelectionOrOpenLinkAtMouseCursor(
+                    CompleteSelection(
                         ClipboardCopyDestination::PrimarySelection
                     )
                 ],


### PR DESCRIPTION
Fixes #212 

## Description
This PR modifies the default mouse click behavior in the terminal to prevent unintended file or link openings. Previously, a single left click without any modifier keys would both complete the text selection and open the link under the cursor. This design caused significant friction because users often single-click to focus the terminal, dismiss selections, or start selecting text. If the cursor happened to be over a file path or URL, it would unexpectedly open it in the editor.

## Changes Made
- Downgraded `Modifiers::NONE` (and other generic combinations like `Modifiers::SHIFT`) from `CompleteSelectionOrOpenLinkAtMouseCursor` to `CompleteSelection`. Now, plain clicks strictly handle selection and focusing, restoring the expected UX of traditional terminal emulators.
- Added a dedicated mapping for `Modifiers::SUPER` (the Command ⌘ key on macOS). Users can now intentionally open links or files by holding the Command key while left-clicking, which aligns with industry standards (e.g., iTerm2, VS Code, macOS Terminal).