### PR TITLE
feat(prompt): show env names in default starship prompt

### DIFF
--- a/assets/vendor/starship.toml
+++ b/assets/vendor/starship.toml
@@ -2,7 +2,7 @@
 
 add_newline = false
 command_timeout = 10000
-format = "$directory$git_branch$package$character"
+format = "$directory$git_branch$python$conda$package$character"
 
 [directory]
 truncate_to_repo = true
@@ -17,6 +17,20 @@ format = "$symbol"
 
 [git_branch]
 format = " [$symbol$branch(:$remote_branch)]($style)"
+
+[python]
+format = ' [\($virtualenv\)]($style)'
+style = 'bold green'
+python_binary = ['python3', 'python']
+detect_extensions = []
+detect_files = []
+detect_folders = []
+detect_env_vars = ['VIRTUAL_ENV']
+
+[conda]
+format = ' [\($environment\)]($style)'
+style = 'bold green'
+ignore_base = false
 
 [package]
 format = " is [$symbol$version]($style)"


### PR DESCRIPTION
## Summary

- show active Python virtualenv names and conda environment names in Kaku's default Starship prompt
- keep the change scoped to `assets/vendor/starship.toml` so Kaku continues to rely on Starship for prompt rendering
- avoid Python version noise by only rendering `python` when `VIRTUAL_ENV` is set

## Problem

Kaku's default Starship prompt currently uses:

```toml
format = "$directory$git_branch$package$character"
```

That means activating a virtual environment does not change the prompt at all, so users cannot see common environment context like `(.venv)` or `(base)` in the place they are already watching.

I initially explored a tab-title-based approach, but that is a poor fit here because single-tab usage can hide the tab bar entirely. Prompt-level environment display is more consistent with how Starship and other prompt ecosystems surface this information.

## Solution

Update Kaku's bundled default `starship.toml` to include `python` and `conda` prompt segments:

- `format = "$directory$git_branch$python$conda$package$character"`
- configure `python` to render only the virtualenv name as `(.venv)`
- configure `conda` to render the active conda environment as `(base)` / `(env)`
- restrict `python` detection to `VIRTUAL_ENV` so Python project files alone do not create an empty or misleading segment

This keeps the change aligned with Kaku's current design: Starship owns prompt rendering, and Kaku only adjusts the bundled default prompt configuration.

## Notes

- This changes the bundled default only.
- Users who already have their own `~/.config/starship.toml` will keep using that file and will not automatically see the new prompt segments until they sync the relevant config.
- This first pass focuses on the most common environment cases: Python virtualenv / virtualenv and conda.

## Testing

Verified locally with the bundled config via `starship prompt`:

```sh
STARSHIP_CONFIG="/path/to/assets/vendor/starship.toml" VIRTUAL_ENV="/tmp/demo/.venv" PWD="/path/to/repo" starship prompt
STARSHIP_CONFIG="/path/to/assets/vendor/starship.toml" CONDA_DEFAULT_ENV="base" PWD="/path/to/repo" starship prompt
STARSHIP_CONFIG="/path/to/assets/vendor/starship.toml" PWD="/tmp/kaku-starship-empty" starship prompt
```

Observed locally:

- `VIRTUAL_ENV=/tmp/demo/.venv` renders `(.venv)`
- `CONDA_DEFAULT_ENV=base` renders `(base)`
- no active environment renders no extra environment segment
