### PR TITLE
docs(readme): remove set-tab-title from command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ config.color_overrides = {
 }
 ```
 
-Run `kaku` in your terminal to see all available commands such as `kaku ai`, `kaku config`, `kaku doctor`, `kaku update`, `kaku reset`, and `kaku set-tab-title`.
+Run `kaku` in your terminal to see all available commands such as `kaku ai`, `kaku config`, `kaku doctor`, `kaku update`, and `kaku reset`.
 
 ## Kaku AI
 


### PR DESCRIPTION
## Summary
- remove the obsolete `kaku set-tab-title` mention from the README command list
- keep the command examples aligned with the current CLI surface

<img width="1010" height="614" alt="image" src="https://github.com/user-attachments/assets/894f565d-be1e-4e49-8787-bbbf55d7efda" />


## Testing
- not run (README-only change)