### PR TITLE
fix(macos): normalize Finder service file targets to parent directories

### DIFF
--- a/window/src/os/macos/app.rs
+++ b/window/src/os/macos/app.rs
@@ -21,6 +21,7 @@ use objc::*;
 use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::ffi::c_void;
+use std::path::Path;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -802,6 +803,17 @@ extern "C" fn keyboard_selection_did_change(
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_test_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("kaku-app-tests-{}-{nanos}", name))
+    }
 
     #[test]
     fn layout_translation_modifier_flags_include_shift_and_option() {
@@ -824,6 +836,42 @@ mod tests {
         let flags = layout_translation_modifier_flags(Modifiers::CTRL | Modifiers::SUPER);
 
         assert_eq!(flags, NSEventModifierFlags::empty());
+    }
+
+    #[test]
+    fn normalize_finder_service_path_uses_parent_for_files() {
+        let dir = unique_test_path("file-parent");
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let file = dir.join("demo.txt");
+        fs::write(&file, "demo").expect("create temp file");
+
+        let normalized = normalize_finder_service_path(file.to_string_lossy().into_owned());
+
+        assert_eq!(normalized, dir.to_string_lossy().into_owned());
+
+        fs::remove_dir_all(&dir).expect("remove temp dir");
+    }
+
+    #[test]
+    fn normalize_finder_service_path_keeps_directories() {
+        let dir = unique_test_path("dir-stays-dir");
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        let normalized = normalize_finder_service_path(dir.to_string_lossy().into_owned());
+
+        assert_eq!(normalized, dir.to_string_lossy().into_owned());
+
+        fs::remove_dir_all(&dir).expect("remove temp dir");
+    }
+
+    #[test]
+    fn normalize_finder_service_path_keeps_unknown_paths() {
+        let path = unique_test_path("missing-path");
+        let path = path.to_string_lossy().into_owned();
+
+        let normalized = normalize_finder_service_path(path.clone());
+
+        assert_eq!(normalized, path);
     }
 }
 
@@ -1004,6 +1052,18 @@ fn first_service_path(pasteboard: *mut Object) -> Option<String> {
     }
 }
 
+fn normalize_finder_service_path(path: String) -> String {
+    let path_ref = Path::new(&path);
+
+    if path_ref.is_file() {
+        if let Some(parent) = path_ref.parent() {
+            return parent.to_string_lossy().into_owned();
+        }
+    }
+
+    path
+}
+
 fn dispatch_or_queue_service_open(path: String, prefer_existing_window: bool) {
     note_service_open_request();
 
@@ -1169,6 +1229,7 @@ extern "C" fn open_in_kaku_service(
         log::warn!("openInKakuService: Finder provided no usable paths");
         return;
     };
+    let path = normalize_finder_service_path(path);
 
     log::debug!("openInKakuService {path}");
     dispatch_or_queue_service_open(path, true);
@@ -1185,6 +1246,7 @@ extern "C" fn open_in_kaku_window_service(
         log::warn!("openInKakuWindowService: Finder provided no usable paths");
         return;
     };
+    let path = normalize_finder_service_path(path);
 
     log::debug!("openInKakuWindowService {path}");
     dispatch_or_queue_service_open(path, false);


### PR DESCRIPTION
## Summary

- Fix Finder `New Kaku Tab Here` / `New Kaku Window Here` forwarding file paths directly into the service open flow
- Normalize explicit file targets to their parent directories while leaving directory targets unchanged
- Keep the change scoped to the Finder service path only, without changing other open-file or URL entry points

Closes #231 

## Root Cause

The macOS Finder service entry points accepted the first incoming path and forwarded it as-is.

That behavior worked for directory targets, but when Finder invoked the service on a file, Kaku propagated the file path itself. Downstream logic then treated that value as a working directory, which caused `not a dir` style failures.

## Changes

1. Add a small path normalization step in the macOS Finder service flow
2. Convert explicit file targets to their parent directories
3. Preserve existing behavior for directory targets and unknown paths
4. Add focused regression tests for:
   - file target -> parent directory
   - directory target -> unchanged
   - unknown path -> unchanged

## Test plan

- [x] `cargo test -p window normalize_finder_service_path -- --nocapture`
- [x] `cargo build -p kaku-gui`
- [x] `make app`
- [x] Manual verification: right-clicking a file in Finder with `New Kaku Tab Here` opens Kaku in the file's parent directory
- [x] Manual verification: right-clicking a file in Finder with `New Kaku Window Here` opens Kaku in the file's parent directory
- [x] Manual verification: right-clicking a directory still behaves the same as before

## Notes

- Local verification also required restoring missing vendored dependency working trees before the build could run successfully
