### PR TITLE
feat(assistant): add User-Agent header to AI API requests

### DIFF
--- a/assets/macos/Kaku.app/Contents/Resources/kaku.lua
+++ b/assets/macos/Kaku.app/Contents/Resources/kaku.lua
@@ -823,6 +823,18 @@ local function ai_fix_endpoint()
   return trim_trailing_whitespace(ai_fix_api_base_url):gsub("/+$", "") .. "/chat/completions"
 end
 
+local function ai_fix_user_agent_version()
+  local version = wezterm and wezterm.version
+  if type(version) ~= "string" or version == "" then
+    return "unknown"
+  end
+  local normalized = trim_surrounding_whitespace(version)
+  if normalized == "" then
+    return "unknown"
+  end
+  return normalized
+end
+
 local function ai_fix_curl_header_args()
   local args = {
     "-H",
@@ -835,6 +847,9 @@ local function ai_fix_curl_header_args()
     args[#args + 1] = "-H"
     args[#args + 1] = header
   end
+
+  args[#args + 1] = "-H"
+  args[#args + 1] = "User-Agent: Kaku/" .. ai_fix_user_agent_version()
 
   return args
 end


### PR DESCRIPTION
## Summary

- Adds a `User-Agent: Kaku/<version>` HTTP header to every AI chat/completions request
- Version is read from `wezterm.version` at runtime, falling back to `"unknown"` if unavailable
- Helps AI providers (VivGrid, MiniMax, OpenAI, custom) identify traffic originating from the Kaku terminal

## Test plan

- [ ] Run `kaku ai` to configure an API key, then trigger a failing shell command and verify the suggestion appears as before
- [ ] Inspect outgoing request headers (e.g. via a proxy or provider dashboard) to confirm `User-Agent: Kaku/<version>` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)