### PR TITLE
fix: support MacPorts and other package managers for tool detection (#263)

### DIFF
--- a/assets/shell-integration/install_cli_tools.sh
+++ b/assets/shell-integration/install_cli_tools.sh
@@ -121,7 +121,7 @@ resolved_tool_path() {
 		return 0
 	fi
 
-	local candidates=("/opt/homebrew/bin/$tool_name" "/usr/local/bin/$tool_name")
+	local candidates=("/opt/homebrew/bin/$tool_name" "/usr/local/bin/$tool_name" "/opt/local/bin/$tool_name")
 
 	# If we already have a brew binary, derive the prefix for tool lookup
 	if [[ -n "${BREW_BIN:-}" && -x "$BREW_BIN" ]]; then

--- a/assets/shell-integration/setup_fish.sh
+++ b/assets/shell-integration/setup_fish.sh
@@ -397,18 +397,22 @@ BLOCK
 
 resolve_real_yazi() {
 	local candidate
-	for candidate in /opt/homebrew/bin/yazi /usr/local/bin/yazi; do
+
+	# Check PATH first so any package manager (MacPorts, Nix, etc.) is found
+	local path_entry
+	IFS=':' read -r -a path_entries <<< "${PATH:-}"
+	for path_entry in "${path_entries[@]}"; do
+		[[ -z "$path_entry" || "$path_entry" == "$WRAPPER_DIR" ]] && continue
+		candidate="$path_entry/yazi"
 		if [[ -x "$candidate" && "$candidate" != "$WRAPPER_PATH" ]]; then
 			printf '%s\n' "$candidate"
 			return 0
 		fi
 	done
 
-	local path_entry
-	IFS=':' read -r -a path_entries <<< "${PATH:-}"
-	for path_entry in "${path_entries[@]}"; do
-		[[ -z "$path_entry" || "$path_entry" == "$WRAPPER_DIR" ]] && continue
-		candidate="$path_entry/yazi"
+	# Fallback to well-known install locations for GUI-launched shells
+	# where PATH may be minimal
+	for candidate in /opt/homebrew/bin/yazi /usr/local/bin/yazi /opt/local/bin/yazi; do
 		if [[ -x "$candidate" && "$candidate" != "$WRAPPER_PATH" ]]; then
 			printf '%s\n' "$candidate"
 			return 0
@@ -658,6 +662,8 @@ ensure_kaku_tmux_integration() {
 		tmux_cmd=/opt/homebrew/bin/tmux
 	elif [[ -x /usr/local/bin/tmux ]]; then
 		tmux_cmd=/usr/local/bin/tmux
+	elif [[ -x /opt/local/bin/tmux ]]; then
+		tmux_cmd=/opt/local/bin/tmux
 	fi
 
 	if [[ -z "$tmux_cmd" ]]; then

--- a/assets/shell-integration/setup_zsh.sh
+++ b/assets/shell-integration/setup_zsh.sh
@@ -405,18 +405,22 @@ BLOCK
 
 resolve_real_yazi() {
 	local candidate
-	for candidate in /opt/homebrew/bin/yazi /usr/local/bin/yazi; do
+
+	# Check PATH first so any package manager (MacPorts, Nix, etc.) is found
+	local path_entry
+	IFS=':' read -r -a path_entries <<< "${PATH:-}"
+	for path_entry in "${path_entries[@]}"; do
+		[[ -z "$path_entry" || "$path_entry" == "$WRAPPER_DIR" ]] && continue
+		candidate="$path_entry/yazi"
 		if [[ -x "$candidate" && "$candidate" != "$WRAPPER_PATH" ]]; then
 			printf '%s\n' "$candidate"
 			return 0
 		fi
 	done
 
-	local path_entry
-	IFS=':' read -r -a path_entries <<< "${PATH:-}"
-	for path_entry in "${path_entries[@]}"; do
-		[[ -z "$path_entry" || "$path_entry" == "$WRAPPER_DIR" ]] && continue
-		candidate="$path_entry/yazi"
+	# Fallback to well-known install locations for GUI-launched shells
+	# where PATH may be minimal
+	for candidate in /opt/homebrew/bin/yazi /usr/local/bin/yazi /opt/local/bin/yazi; do
 		if [[ -x "$candidate" && "$candidate" != "$WRAPPER_PATH" ]]; then
 			printf '%s\n' "$candidate"
 			return 0
@@ -1491,6 +1495,8 @@ has_kaku_tmux_source_line() {
 ensure_kaku_tmux_integration() {
 	# GUI-launched shells inherit a minimal PATH (no Homebrew). Probe common
 	# install locations so tmux is found even when PATH is stripped down.
+	# GUI-launched shells inherit a minimal PATH (no Homebrew/MacPorts). Probe
+	# common install locations so tmux is found even when PATH is stripped down.
 	local tmux_cmd=""
 	if command -v tmux >/dev/null 2>&1; then
 		tmux_cmd="tmux"
@@ -1498,6 +1504,8 @@ ensure_kaku_tmux_integration() {
 		tmux_cmd=/opt/homebrew/bin/tmux
 	elif [[ -x /usr/local/bin/tmux ]]; then
 		tmux_cmd=/usr/local/bin/tmux
+	elif [[ -x /opt/local/bin/tmux ]]; then
+		tmux_cmd=/opt/local/bin/tmux
 	fi
 
 	if [[ -z "$tmux_cmd" ]]; then

--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -153,6 +153,7 @@ const VSCODE_OPEN_CANDIDATES: &[&str] = &[
     "code",
     "/usr/local/bin/code",
     "/opt/homebrew/bin/code",
+    "/opt/local/bin/code",
     "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
 ];
 

--- a/kaku/src/utils.rs
+++ b/kaku/src/utils.rs
@@ -113,6 +113,7 @@ fn try_vscode(path: &Path) -> anyhow::Result<bool> {
         "code".to_string(),
         "/usr/local/bin/code".to_string(),
         "/opt/homebrew/bin/code".to_string(),
+        "/opt/local/bin/code".to_string(),
         "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code".to_string(),
     ];
 


### PR DESCRIPTION
Prioritize PATH-based detection over hardcoded Homebrew paths so tools
installed via MacPorts, Nix, or other package managers are recognized.
Add /opt/local/bin (MacPorts) to fallback candidate paths.

https://claude.ai/code/session_01Geus2CBiivoy6VzHB2E3XH