### PR TITLE
fix(macos): prevent use-after-free crash during window close with fullscreen transition

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -2763,6 +2763,9 @@ struct WindowView {
     native_fullscreen_target: Cell<Option<bool>>,
     native_fullscreen_transition_start: Cell<Option<Instant>>,
     resize_retry_scheduled: Cell<bool>,
+    /// Set when window_will_close fires; prevents fullscreen transition
+    /// handlers from dispatching events to an already-destroyed window.
+    is_closing: Cell<bool>,
 }
 
 fn arm_display_change_opengl_present_defer(
@@ -3785,6 +3788,13 @@ impl WindowView {
     }
 
     extern "C" fn window_will_close(this: &mut Object, _sel: Sel, _id: id) {
+        // Mark the window as closing BEFORE any cleanup so that fullscreen
+        // transition handlers (will_exit_fullscreen, did_exit_fullscreen) that
+        // AppKit may fire during [NSWindow _close] will bail out instead of
+        // dispatching events into an already-destroyed TermWindow.
+        if let Some(view) = Self::get_this(this) {
+            view.is_closing.set(true);
+        }
         Self::cancel_pending_perform_requests(this as *mut Object);
         Self::detach_backing_layer(this);
         if let Some(this) = Self::get_this(this) {
@@ -4527,6 +4537,9 @@ impl WindowView {
 
     extern "C" fn will_enter_fullscreen(this: &mut Object, _sel: Sel, _notification: id) {
         if let Some(this) = Self::get_this(this) {
+            if this.is_closing.get() {
+                return;
+            }
             this.native_fullscreen_transition_active.set(true);
             this.native_fullscreen_target.set(Some(true));
             this.native_fullscreen_transition_start
@@ -4561,6 +4574,9 @@ impl WindowView {
 
     extern "C" fn did_enter_fullscreen(this: &mut Object, _sel: Sel, _notification: id) {
         if let Some(this) = Self::get_this(this) {
+            if this.is_closing.get() {
+                return;
+            }
             this.native_fullscreen_transition_active.set(false);
             this.native_fullscreen_target.set(None);
             if let Ok(mut inner) = this.inner.try_borrow_mut() {
@@ -4569,6 +4585,9 @@ impl WindowView {
         }
         Self::did_resize(this, _sel, _notification);
         if let Some(this) = Self::get_this(this) {
+            if this.is_closing.get() {
+                return;
+            }
             this.native_fullscreen_transition_start.set(None);
             {
                 let mut inner = this.inner.borrow_mut();
@@ -4587,6 +4606,9 @@ impl WindowView {
     extern "C" fn will_exit_fullscreen(this: &mut Object, _sel: Sel, _notification: id) {
         let view_id = this as *mut Object;
         if let Some(this) = Self::get_this(this) {
+            if this.is_closing.get() {
+                return;
+            }
             let now = Instant::now();
             this.native_fullscreen_transition_active.set(true);
             this.native_fullscreen_target.set(Some(false));
@@ -4612,6 +4634,9 @@ impl WindowView {
     extern "C" fn did_exit_fullscreen(this: &mut Object, _sel: Sel, _notification: id) {
         let view_id = this as *mut Object;
         if let Some(this) = Self::get_this(this) {
+            if this.is_closing.get() {
+                return;
+            }
             this.native_fullscreen_transition_active.set(false);
             this.native_fullscreen_target.set(None);
             this.transition_hide_until.set(None);
@@ -4621,6 +4646,9 @@ impl WindowView {
         }
         Self::did_resize(this, _sel, _notification);
         if let Some(this) = Self::get_this(this) {
+            if this.is_closing.get() {
+                return;
+            }
             this.native_fullscreen_transition_start.set(None);
             {
                 if let Ok(mut inner) = this.inner.try_borrow_mut() {
@@ -5086,6 +5114,7 @@ impl WindowView {
             native_fullscreen_target: Cell::new(None),
             native_fullscreen_transition_start: Cell::new(None),
             resize_retry_scheduled: Cell::new(false),
+            is_closing: Cell::new(false),
         }));
 
         unsafe {


### PR DESCRIPTION
## Problem

When closing a window while it is in a fullscreen transition (entering or exiting), AppKit continues to fire transition callbacks (`will/did_enter/exit_fullscreen`) after the window has already been deallocated, causing a use-after-free crash.

## Fix

- Add an `is_closing: Cell<bool>` flag to `WindowView`
- Set the flag to `true` at the start of `window_will_close`, before any cleanup
- Guard all fullscreen transition handlers with an early return when `is_closing` is set
- Replace `borrow_mut()` with `try_borrow_mut()` in transition handlers to avoid `BorrowMutError` panics when AppKit fires notifications synchronously while `inner` is already borrowed during close

## Testing

Reproduce: open a window, enter fullscreen, then immediately close the window before the transition completes. Without this fix, the app crashes. With this fix, the transition callbacks are safely ignored.