### PR TITLE
fix(clipboard): avoid clearing clipboard on empty cmd-c

### DIFF
--- a/kaku-gui/src/termwindow/clipboard.rs
+++ b/kaku-gui/src/termwindow/clipboard.rs
@@ -40,6 +40,18 @@ fn should_emit_ai_notice(kind: &str, message: &str) -> bool {
 }
 
 impl TermWindow {
+    pub fn copy_to_clipboard_if_present(
+        &self,
+        clipboard: ClipboardCopyDestination,
+        text: String,
+    ) -> bool {
+        let Some(text) = clipboard_text_if_present(text) else {
+            return false;
+        };
+        self.copy_to_clipboard(clipboard, text);
+        true
+    }
+
     pub fn copy_to_clipboard(&self, clipboard: ClipboardCopyDestination, text: String) {
         let clipboard = match clipboard {
             ClipboardCopyDestination::Clipboard => [Some(Clipboard::Clipboard), None],
@@ -210,6 +222,14 @@ impl TermWindow {
     }
 }
 
+fn clipboard_text_if_present(text: String) -> Option<String> {
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
 fn data_to_paste_string(
     data: ClipboardData,
     quote_dropped_files: config::DroppedFileQuoting,
@@ -236,6 +256,24 @@ fn format_dropped_paths(
         .collect::<Vec<_>>()
         .join(" ")
         + " " // Trailing space so the shell treats this as ready-to-append arguments.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clipboard_text_if_present;
+
+    #[test]
+    fn clipboard_text_if_present_skips_empty_strings() {
+        assert_eq!(clipboard_text_if_present(String::new()), None);
+    }
+
+    #[test]
+    fn clipboard_text_if_present_keeps_non_empty_strings() {
+        assert_eq!(
+            clipboard_text_if_present("selected text".to_string()),
+            Some("selected text".to_string())
+        );
+    }
 }
 
 fn quote_path_for_clipboard_paste(

--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -4012,7 +4012,7 @@ impl TermWindow {
             }
             CopyTo(dest) => {
                 let text = self.selection_text(pane);
-                self.copy_to_clipboard(*dest, text);
+                self.copy_to_clipboard_if_present(*dest, text);
             }
             CopyTextTo { text, destination } => {
                 self.copy_to_clipboard(*destination, text.clone());


### PR DESCRIPTION
## Summary

  Fix a clipboard regression when `copy_on_select` is enabled.

  Previously, selecting text with the mouse correctly copied the selection to the clipboard, but pressing `Cmd+C` on the same
  selection could overwrite the clipboard with an empty string. This broke the expected idempotent behavior of copy.

## Root Cause

  The mouse-selection completion path already guarded against empty selection text before writing to the clipboard.

  The `Cmd+C` path (`CopyTo`) did not. It recomputed `selection_text()` and always wrote the result to the macOS pasteboard.
  If that recomputation returned an empty string, the clipboard was cleared.

## Changes

  - Add a guarded clipboard helper that only writes when the text is non-empty.
  - Route the `Cmd+C` / `CopyTo` path through that helper.
  - Keep explicit text-copy paths unchanged.
  - Add regression tests for the empty/non-empty clipboard text guard.