### PR TITLE
fix(config): exclude trailing punctuation and wrappers from file link regex

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -2109,8 +2109,16 @@ pub fn default_hyperlink_rules() -> Vec<hyperlink::Rule> {
         // File paths: support absolute paths, common relative prefixes, and
         // bare relative paths like `kaku/src/main.rs`.
         // Supports file:line and file:line:col formats.
+        //
+        // The trailing character class is intentionally restricted to ASCII
+        // word/`/`/`-` so that trailing punctuation (`.`, `,`, `;`, `:`, `!`,
+        // `?`), CJK particles (e.g. Korean `에`/`을`), or matched wrappers
+        // (backticks, quotes) attached after a path are excluded from the
+        // match via regex backtracking. The leading boundary class likewise
+        // admits backticks and straight quotes so a path wrapped in those
+        // characters is still detected.
         hyperlink::Rule::with_highlight(
-            r"(^|[\s\(\[<])((?:~|\.{1,2}|[[:alnum:]_.-]+)?/[^\s\)\]\}>]+)",
+            r#"(^|[\s\(\[<`'"])((?:~|\.{1,2}|[[:alnum:]_.-]+)?/[^\s\)\]\}>`'"]*[a-zA-Z0-9_/-])"#,
             "file://$2",
             2,
         )
@@ -2156,6 +2164,112 @@ mod tests {
                 )),
             })
         );
+    }
+
+    /// Helper: find the file:// hyperlink match in `text`, returning the
+    /// resolved URI. Asserts exactly one file match exists.
+    fn file_uri(text: &str) -> String {
+        let rules = default_hyperlink_rules();
+        let matches: Vec<_> = Rule::match_hyperlinks(text, &rules)
+            .into_iter()
+            .filter(|m| m.link.uri().starts_with("file://"))
+            .collect();
+        assert_eq!(
+            matches.len(),
+            1,
+            "expected exactly one file:// match in {text:?}, got {matches:?}",
+        );
+        matches.into_iter().next().unwrap().link.uri().to_string()
+    }
+
+    #[test]
+    fn file_hyperlink_trims_trailing_ascii_punctuation() {
+        // Sentence-final punctuation should not be swallowed into the link.
+        assert_eq!(file_uri("see docs/foo.md."), "file://docs/foo.md");
+        assert_eq!(file_uri("see docs/foo.md,"), "file://docs/foo.md");
+        assert_eq!(file_uri("see docs/foo.md;"), "file://docs/foo.md");
+        assert_eq!(file_uri("is docs/foo.md?"), "file://docs/foo.md");
+        assert_eq!(file_uri("yes docs/foo.md!"), "file://docs/foo.md");
+        assert_eq!(file_uri("path: docs/foo.md: here"), "file://docs/foo.md");
+    }
+
+    #[test]
+    fn file_hyperlink_trims_trailing_korean_particles() {
+        // A Korean particle attached to a path (no space) is a common
+        // pattern; the particle must be excluded from the match.
+        assert_eq!(
+            file_uri("docs/foo.md\u{C5D0} \u{C800}\u{C7A5}"),
+            "file://docs/foo.md"
+        );
+        assert_eq!(
+            file_uri("\u{C774} docs/foo.md\u{B97C} \u{C5F4}\u{C5B4}"),
+            "file://docs/foo.md"
+        );
+        assert_eq!(
+            file_uri("docs/foo.md\u{C740} \u{C5C5}"),
+            "file://docs/foo.md"
+        );
+    }
+
+    #[test]
+    fn file_hyperlink_handles_wrapping_delimiters() {
+        // Backtick/quote wrappers commonly appear around paths in prose or
+        // markdown rendered to the terminal; both sides must be stripped.
+        assert_eq!(file_uri("see `docs/foo.md` now"), "file://docs/foo.md");
+        assert_eq!(file_uri("see 'docs/foo.md' now"), "file://docs/foo.md");
+        assert_eq!(file_uri("see \"docs/foo.md\" now"), "file://docs/foo.md");
+        assert_eq!(file_uri("see (docs/foo.md) now"), "file://docs/foo.md");
+    }
+
+    #[test]
+    fn file_hyperlink_preserves_line_and_column() {
+        // file:line and file:line:col suffixes must still be captured so
+        // that the click handler can jump to the right position.
+        assert_eq!(
+            file_uri("see docs/foo.md:42 now"),
+            "file://docs/foo.md:42"
+        );
+        assert_eq!(
+            file_uri("see docs/foo.md:42:10 now"),
+            "file://docs/foo.md:42:10"
+        );
+        assert_eq!(
+            file_uri("see docs/foo.md:42:10."),
+            "file://docs/foo.md:42:10"
+        );
+    }
+
+    #[test]
+    fn file_hyperlink_handles_absolute_paths_with_particles() {
+        // Regression: the motivating bug — an absolute path followed by
+        // the Korean locative particle.
+        assert_eq!(
+            file_uri(
+                "\u{C800}\u{C7A5}: /Users/x/Code/proj/docs/plans/2026-04-18-v8-plan.md\u{C5D0} \u{C0DD}\u{C131}"
+            ),
+            "file:///Users/x/Code/proj/docs/plans/2026-04-18-v8-plan.md"
+        );
+    }
+
+    #[test]
+    fn file_hyperlink_is_extension_neutral() {
+        // The match logic is purely about the last character being ASCII
+        // word/`/`/`-`, so arbitrary source-file extensions are handled
+        // the same way `.md` is. This test pins that invariant so a
+        // future change cannot accidentally re-introduce an extension
+        // bias.
+        assert_eq!(file_uri("src/main.rs\u{B294}"), "file://src/main.rs");
+        assert_eq!(file_uri("open src/main.rs."), "file://src/main.rs");
+        assert_eq!(file_uri("see `src/lib.rs` ok"), "file://src/lib.rs");
+        assert_eq!(file_uri("pkg/util.py\u{C5D0}"), "file://pkg/util.py");
+        assert_eq!(file_uri("see app/index.ts."), "file://app/index.ts");
+        assert_eq!(file_uri("cmd/server.go:128:"), "file://cmd/server.go:128");
+        assert_eq!(file_uri("data/out.json,"), "file://data/out.json");
+        assert_eq!(file_uri("infra/.env.local."), "file://infra/.env.local");
+        // Extensionless files (Makefile-style) still work because the
+        // last character is an ASCII letter.
+        assert_eq!(file_uri("see ./Makefile."), "file://./Makefile");
+        assert_eq!(file_uri("see docker/Dockerfile,"), "file://docker/Dockerfile");
     }
 }
 


### PR DESCRIPTION
## Summary

The implicit file-path hyperlink rule matched one character too far past the end of the actual path, so clicking a detected link was often a silent no-op.

**Cases the current regex fails on:**

- Sentence-final punctuation: `see docs/foo.md.`, `see docs/foo.md,`, `open docs/foo.md?`
- CJK particles attached without whitespace — very common in Korean prose emitted by AI CLI tools:
  - `docs/foo.md에 저장했습니다` (locative)
  - `docs/foo.md를 열어주세요` (object)
  - `docs/foo.md은 업데이트됨` (topic)
- Matched wrapper characters: `` `docs/foo.md` ``, `'docs/foo.md'`, `"docs/foo.md"`

In each case the rule captures `docs/foo.md.` / `docs/foo.md에` / `` docs/foo.md` `` and builds a `file://...` URI that doesn't exist on disk. The click handler's `target.path.exists()` check fails, so the click does nothing even though the path is visibly underlined.

## Fix

Change the trailing portion of the rule so the last captured character must be an ASCII word character, `/`, or `-`:

```diff
- r"(^|[\s\(\[<])((?:~|\.{1,2}|[[:alnum:]_.-]+)?/[^\s\)\]\}>]+)"
+ r#"(^|[\s\(\[<`'"])((?:~|\.{1,2}|[[:alnum:]_.-]+)?/[^\s\)\]\}>`'"]*[a-zA-Z0-9_/-])"#
```

Regex backtracking naturally drops trailing characters that don't fit, so `docs/foo.md에` backtracks to `docs/foo.md`. Backticks and straight quotes are added to the leading boundary class and excluded from the inner class so wrapped paths are detected with the wrappers stripped.

**The rule remains extension-neutral** — `.rs`, `.py`, `.ts`, `.go`, `.json`, extensionless files like `Makefile`/`Dockerfile`, and dotfile-style `.env.local` all continue to match because they end in an ASCII letter or digit. `file:line` and `file:line:col` suffixes are preserved for the same reason (trailing digit).

## Test plan

- [x] `cargo test -p config --lib` — 36 passed, 0 failed
- Existing tests untouched: `file_hyperlink_rule_matches_bare_relative_paths`, `file_hyperlink_rule_does_not_override_urls`
- New tests:
  - `file_hyperlink_trims_trailing_ascii_punctuation` — `.`, `,`, `;`, `:`, `!`, `?`
  - `file_hyperlink_trims_trailing_korean_particles` — `에`, `를`, `은`
  - `file_hyperlink_handles_wrapping_delimiters` — backtick, single quote, double quote, parentheses
  - `file_hyperlink_preserves_line_and_column` — `:42`, `:42:10`, and `:42:10.` regressions
  - `file_hyperlink_handles_absolute_paths_with_particles` — the motivating bug: `/Users/x/Code/proj/docs/plans/2026-04-18-v8-plan.md` followed by `에`
  - `file_hyperlink_is_extension_neutral` — pins the invariant across `.rs`, `.py`, `.ts`, `.go`, `.json`, `.env.local`, `Makefile`, `Dockerfile`