### PR TITLE
fix: reset viewport on window resize to prevent content jump and loss

### DIFF
--- a/kaku-gui/src/termwindow/resize.rs
+++ b/kaku-gui/src/termwindow/resize.rs
@@ -555,6 +555,12 @@ impl super::TermWindow {
                     tab.resize(size);
                 }
             }
+            for tab in window.iter() {
+                for pos in tab.iter_panes_ignoring_zoom() {
+                    let mut state = self.pane_state(pos.pane.pane_id());
+                    state.viewport = None;
+                }
+            }
         };
         if live {
             self.pending_pty_flush_after_resize = true;

--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -224,10 +224,18 @@ impl Screen {
         // pre-prune blank lines that range from the cursor position to the end of the display;
         // this avoids growing the scrollback size when rapidly switching between normal and
         // maximized states.
+        // Limit pruning to lines beyond the visible viewport to avoid losing
+        // scrollback content during repeated resizes.
         let cursor_phys = self.phys_row(cursor.y);
+        let max_prune = self.lines.len().saturating_sub(self.physical_rows);
+        let mut pruned = 0;
         for _ in cursor_phys + 1..self.lines.len() {
+            if pruned >= max_prune {
+                break;
+            }
             if self.lines.back().map(Line::is_whitespace).unwrap_or(false) {
                 self.lines.pop_back();
+                pruned += 1;
             }
         }
 


### PR DESCRIPTION
## Summary
- Reset all pane viewports to bottom after every window resize in `apply_dimensions()`, preventing content from appearing to jump or becoming inaccessible
- Limit pre-prune blank line removal in `Screen::resize()` to avoid cumulative content loss during repeated resizes

## Problem
When resizing the terminal window:
1. The last line of content jumps upward
2. Cannot scroll up to see previous content
3. Repeated resizes progressively clear terminal content

## Root Cause
`physical_top` shifts on resize because both `lines.len()` and `physical_rows` change, but `PaneState::viewport` was never adjusted. Additionally, the pre-prune loop in `Screen::resize()` had no upper bound, causing cumulative content loss.

## Test Plan
- [ ] Output several screenfuls of content, then resize the window — content should not jump
- [ ] After resize, scroll up — all previous content should be accessible
- [ ] Rapidly resize multiple times — content should not be cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)