### PR TITLE
Fix: Cursor reflow corruption on resize(#301)

### DIFF
--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -158,7 +158,7 @@ impl Screen {
                 // line and it won't resize with the line correctly.
                 // Put it back on the prior line. The cursor is now
                 // technically outside of the viewport width.
-                if adjusted_cursor.0 == 0 && adjusted_cursor.1 > 0 {
+                if adjusted_cursor.0 == 0 && num_lines > 0 {
                     if physical_cols < self.physical_cols {
                         // getting smaller: preserve its original position
                         // on the prior line


### PR DESCRIPTION
大佬好! Thanks for the recent fixes on the macOS dimension desync (in 85b3fe9 and c9857f7). While testing those changes, I noticed another deep-rooted issue related to terminal resizing and text reflow, which is addressed in this PR.

The Issue: Cursor Reflow Corruption
Currently, if a script is continuously printing output in the foreground (e.g., while true; do stty size; sleep 1; done), merely resizing the window will cause the text layout to become severely skewed, indented incorrectly, and even overwrite previous lines (like the shell prompt).

Before fix:
<img width="894" height="867" alt="image" src="https://github.com/user-attachments/assets/323d04cb-08a8-4aac-8d8b-802391b8bd54" />
After fix:
<img width="948" height="816" alt="image" src="https://github.com/user-attachments/assets/8ddae65f-3477-4728-95dc-70e686886fcb" />

Root Cause(I use /hunt btw 哈哈): In term/src/screen.rs (the rewrap_lines algorithm), the condition if adjusted_cursor.0 == 0 && adjusted_cursor.1 > 0 was too broad. It mistakenly assumed that any cursor landing at column 0 belongs to a wrapped line. Thus, it forced the cursor back to the end of the previous logical line during resize. When the next raw text is written, it starts out-of-bounds, causing broken stair-step indentations.

Solution: I tightened the condition to if adjusted_cursor.0 == 0 && num_lines > 0. This strictly limits the backward cursor movement to cursors that are genuinely on a continuation physical line of the same wrapped logical line. This safely eliminates the layout corruption without affecting normal wrapping behavior.

💡 An Additional Suggestion: True Dynamic PTY Scaling
While investigating this, I noticed that kaku-gui/src/termwindow/resize.rs uses resize_visual during live_resizing to block PTY dimension updates.

Since the underlying cursor reflow bug is now fixed by this PR, the PTY can actually handle real-time SIGWINCH signals perfectly without corrupting the layout. If you'd like Kaku to have fluid, real-time dynamic scaling (similar to Ghostty) instead of snapping to size when the drag ends, you could simply remove the live check in resize.rs and unconditionally call tab.resize(size).

I'll leave that up to you based on your performance considerations, but this PR focuses purely on fixing the core reflow bug so the terminal remains stable.

Thanks again for maintaining this awesome project, please review~