### PR TITLE
perf(mux): eliminate per-subscriber MuxNotification clones in hot path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ website/dist/
 website/.astro/
 website/test-results/
 website/playwright-report/
+.worktrees/

--- a/crates/kaku-remote/src/lib.rs
+++ b/crates/kaku-remote/src/lib.rs
@@ -805,7 +805,7 @@ pub fn start_tunnel(tunnel_url: String) {
         let tunnel_throttle: PaneThrottle = Arc::new(Mutex::new(HashMap::new()));
         mux.subscribe(move |notification| {
             if let MuxNotification::PaneOutput(pane_id) = notification {
-                let pid: usize = pane_id.into();
+                let pid: usize = (*pane_id).into();
                 if tx_for_sub.receiver_count() > 0 {
                     {
                         let mut times = tunnel_throttle.lock();
@@ -999,13 +999,13 @@ pub fn start() {
             match notification {
                 MuxNotification::PaneOutput(pane_id) => {
                     on_pane_output(
-                        pane_id.into(),
+                        (*pane_id).into(),
                         senders_for_sub.clone(),
                         throttle_for_sub.clone(),
                     );
                 }
                 MuxNotification::PaneRemoved(pane_id) => {
-                    let id: usize = pane_id.into();
+                    let id: usize = (*pane_id).into();
                     senders_for_sub.lock().remove(&id);
                     throttle_for_sub.lock().remove(&id);
                 }

--- a/crates/wezterm-client/src/domain.rs
+++ b/crates/wezterm-client/src/domain.rs
@@ -399,7 +399,7 @@ impl ClientDomain {
     pub fn new(config: ClientDomainConfig) -> Self {
         let local_domain_id = alloc_domain_id();
         let label = config.label();
-        Mux::get().subscribe(move |notif| mux_notify_client_domain(local_domain_id, notif));
+        Mux::get().subscribe(move |notif| mux_notify_client_domain(local_domain_id, notif.clone()));
         Self {
             config,
             label,

--- a/crates/wezterm-mux-server-impl/src/dispatch.rs
+++ b/crates/wezterm-mux-server-impl/src/dispatch.rs
@@ -61,7 +61,7 @@ where
     {
         let mux = Mux::get();
         let tx = item_tx.clone();
-        mux.subscribe(move |n| tx.try_send(Item::Notif(n)).is_ok());
+        mux.subscribe(move |n| tx.try_send(Item::Notif(n.clone())).is_ok());
     }
 
     loop {

--- a/kaku-gui/src/frontend.rs
+++ b/kaku-gui/src/frontend.rs
@@ -327,6 +327,7 @@ impl GuiFrontEnd {
         });
 
         mux.subscribe(move |n| {
+            let n = n.clone();
             match n {
                 MuxNotification::WorkspaceRenamed {
                     old_workspace,

--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -2627,6 +2627,7 @@ impl TermWindow {
 
             let window = window.clone();
             let dead = dead.clone();
+            let n = n.clone();
             promise::spawn::spawn_into_main_thread(async move {
                 Self::mux_pane_output_event_callback(n, &window, mux_window_id, &dead)
             })

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -160,7 +160,7 @@ pub struct Mux {
     default_domain: RwLock<Option<Arc<dyn Domain>>>,
     domains: RwLock<HashMap<DomainId, Arc<dyn Domain>>>,
     domains_by_name: RwLock<HashMap<String, Arc<dyn Domain>>>,
-    subscribers: RwLock<HashMap<usize, Arc<dyn Fn(MuxNotification) -> bool + Send + Sync>>>,
+    subscribers: RwLock<HashMap<usize, Arc<dyn Fn(&MuxNotification) -> bool + Send + Sync>>>,
     banner: RwLock<Option<String>>,
     clients: RwLock<HashMap<ClientId, ClientInfo>>,
     identity: RwLock<Option<Arc<ClientId>>>,
@@ -1063,7 +1063,7 @@ impl Mux {
 
     pub fn subscribe<F>(&self, subscriber: F)
     where
-        F: Fn(MuxNotification) -> bool + 'static + Send + Sync,
+        F: Fn(&MuxNotification) -> bool + 'static + Send + Sync,
     {
         let sub_id = SUB_ID.fetch_add(1, Ordering::Relaxed);
         self.subscribers
@@ -1084,7 +1084,7 @@ impl Mux {
         let to_remove: Vec<usize> = subscribers
             .into_iter()
             .filter_map(|(sub_id, notify)| {
-                if !notify(notification.clone()) {
+                if !notify(&notification) {
                     Some(sub_id)
                 } else {
                     None

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1073,7 +1073,7 @@ impl Mux {
 
     pub fn notify(&self, notification: MuxNotification) {
         // Collect subscribers while holding the lock briefly
-        let subscribers: Vec<(usize, Arc<dyn Fn(MuxNotification) -> bool + Send + Sync>)> = self
+        let subscribers: Vec<(usize, Arc<dyn Fn(&MuxNotification) -> bool + Send + Sync>)> = self
             .subscribers
             .read()
             .iter()

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -570,6 +570,7 @@ impl TmuxDomainState {
         let mux = Mux::get();
         let domain_id = self.domain_id;
         mux.subscribe(move |n| {
+            let n = n.clone();
             promise::spawn::spawn_into_main_thread(async move {
                 let mux = Mux::get();
                 let domain = match mux.get_domain(domain_id) {


### PR DESCRIPTION
   ## Summary

   - Change `Mux::subscribe()` to accept `Fn(&MuxNotification) -> bool` instead of `Fn(MuxNotification) -> bool`
   - `notify()` now passes `&notification` to each subscriber, removing the per-subscriber `.clone()` call
   - Subscribers that need ownership (dispatch channel, client domain, tmux commands, termwindow spawn) clone explicitly at their call site; read-only subscribers
   dereference `PaneId` directly

   ## Motivation

   `MuxNotification::PaneOutput` is emitted thousands of times per second during active terminal output. With the previous design, every notification was cloned once
    per registered subscriber — O(N × subscribers) heap allocations — even though most subscribers only read the `PaneId` and return early.

   Notable `MuxNotification` variants that carry heap-allocated data:
   - `TabTitleChanged { title: String }`
   - `WindowTitleChanged { title: String }`
   - `WorkspaceRenamed { old_workspace: String, new_workspace: String }`

   These clones were unconditional regardless of whether the subscriber ever used the value.

   ## Changes

   | File | Change |
   |------|--------|
   | `mux/src/lib.rs` | Subscriber type → `Fn(&MuxNotification) -> bool`; `notify()` passes `&notification` |
   | `mux/src/tmux_commands.rs` | `let n = n.clone()` before `spawn_into_main_thread` |

  - [ ] Build `mux`, `kaku-gui`, `crates/kaku-remote`, `crates/wezterm-client`, `crates/wezterm-mux-server-impl` successfully
  - [ ] Verify tmux integration still handles `PaneFocused` notifications