### PR TITLE
Add configurable file link open targets

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -222,6 +222,9 @@ pub struct Config {
     #[dynamic(default = "default_gui_startup_args")]
     pub default_gui_startup_args: Vec<String>,
 
+    #[dynamic(default)]
+    pub default_open_target: DefaultOpenTarget,
+
     /// Specifies the default current working directory if none is specified
     /// through configuration or OSC 7 (see docs for `default_cwd` for more
     /// info!)
@@ -2135,9 +2138,31 @@ fn default_harfbuzz_features() -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::default_hyperlink_rules;
+    use super::{default_hyperlink_rules, Config, DefaultOpenTarget};
     use std::sync::Arc;
     use termwiz::hyperlink::{Hyperlink, Rule, RuleMatch};
+    use wezterm_dynamic::{FromDynamic, ToDynamic};
+
+    #[test]
+    fn default_open_target_defaults_to_auto() {
+        let cfg = Config::default();
+        assert_eq!(cfg.default_open_target, DefaultOpenTarget::Auto);
+    }
+
+    #[test]
+    fn default_open_target_round_trips_from_lua_string() {
+        let value = wezterm_dynamic::Value::String("Cursor".to_string());
+        let parsed =
+            DefaultOpenTarget::from_dynamic(&value, wezterm_dynamic::FromDynamicOptions::default())
+                .expect("parse Cursor target");
+        assert_eq!(parsed, DefaultOpenTarget::Cursor);
+
+        let serialized = parsed.to_dynamic();
+        assert_eq!(
+            serialized,
+            wezterm_dynamic::Value::String("Cursor".to_string())
+        );
+    }
 
     #[test]
     fn file_hyperlink_rule_matches_bare_relative_paths() {
@@ -2504,6 +2529,83 @@ impl DefaultCursorStyle {
             },
             _ => shape,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DefaultOpenTarget {
+    #[default]
+    Auto,
+    VsCode,
+    Cursor,
+    Windsurf,
+    Kiro,
+    Antigravity,
+    Zed,
+    IntelliJIdea,
+    DefaultApp,
+    Finder,
+    Terminal,
+    ITerm2,
+    Ghostty,
+    WezTerm,
+    Cmux,
+}
+
+impl DefaultOpenTarget {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "Auto",
+            Self::VsCode => "VS Code",
+            Self::Cursor => "Cursor",
+            Self::Windsurf => "Windsurf",
+            Self::Kiro => "Kiro",
+            Self::Antigravity => "Antigravity",
+            Self::Zed => "Zed",
+            Self::IntelliJIdea => "IntelliJ IDEA",
+            Self::DefaultApp => "Default app",
+            Self::Finder => "Finder",
+            Self::Terminal => "Terminal",
+            Self::ITerm2 => "iTerm2",
+            Self::Ghostty => "Ghostty",
+            Self::WezTerm => "WezTerm",
+            Self::Cmux => "cmux",
+        }
+    }
+}
+
+impl FromDynamic for DefaultOpenTarget {
+    fn from_dynamic(
+        value: &wezterm_dynamic::Value,
+        options: wezterm_dynamic::FromDynamicOptions,
+    ) -> Result<Self, wezterm_dynamic::Error> {
+        let s = String::from_dynamic(value, options)?;
+        match s.as_str() {
+            "Auto" => Ok(Self::Auto),
+            "VS Code" => Ok(Self::VsCode),
+            "Cursor" => Ok(Self::Cursor),
+            "Windsurf" => Ok(Self::Windsurf),
+            "Kiro" => Ok(Self::Kiro),
+            "Antigravity" => Ok(Self::Antigravity),
+            "Zed" => Ok(Self::Zed),
+            "IntelliJ IDEA" => Ok(Self::IntelliJIdea),
+            "Default app" => Ok(Self::DefaultApp),
+            "Finder" => Ok(Self::Finder),
+            "Terminal" => Ok(Self::Terminal),
+            "iTerm2" => Ok(Self::ITerm2),
+            "Ghostty" => Ok(Self::Ghostty),
+            "WezTerm" => Ok(Self::WezTerm),
+            "cmux" => Ok(Self::Cmux),
+            s => Err(wezterm_dynamic::Error::Message(format!(
+                "`{s}` is not a valid default open target"
+            ))),
+        }
+    }
+}
+
+impl ToDynamic for DefaultOpenTarget {
+    fn to_dynamic(&self) -> wezterm_dynamic::Value {
+        self.as_str().to_dynamic()
     }
 }
 

--- a/kaku-gui/src/main.rs
+++ b/kaku-gui/src/main.rs
@@ -104,6 +104,7 @@ mod download;
 mod frontend;
 mod glyphcache;
 mod inputmap;
+mod open_target;
 mod overlay;
 mod quad;
 mod renderstate;

--- a/kaku-gui/src/open_target.rs
+++ b/kaku-gui/src/open_target.rs
@@ -1,0 +1,1309 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::Context;
+use config::DefaultOpenTarget;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileOpenTarget {
+    pub path: PathBuf,
+    pub line: Option<usize>,
+    pub col: Option<usize>,
+    pub is_dir: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenCommand {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+pub trait CommandRunner {
+    fn run(&mut self, command: &OpenCommand) -> anyhow::Result<bool>;
+}
+
+pub struct ProcessCommandRunner;
+
+impl CommandRunner for ProcessCommandRunner {
+    fn run(&mut self, command: &OpenCommand) -> anyhow::Result<bool> {
+        let status = Command::new(&command.program)
+            .args(&command.args)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status();
+
+        match status {
+            Ok(status) if status.success() => Ok(true),
+            Ok(status) => {
+                log::debug!("`{}` exited with status {status}", command.program);
+                Ok(false)
+            }
+            Err(err) => {
+                log::debug!(
+                    "open target command `{}` failed to launch: {err}",
+                    command.program
+                );
+                Ok(false)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct EditorEnv {
+    pub visual: Option<String>,
+    pub editor: Option<String>,
+}
+
+impl EditorEnv {
+    pub fn current() -> Self {
+        Self {
+            visual: std::env::var_os("VISUAL").map(|value| value.to_string_lossy().into_owned()),
+            editor: std::env::var_os("EDITOR").map(|value| value.to_string_lossy().into_owned()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocationStyle {
+    GotoFlag,
+    PathSuffix,
+    LineColumnFlags,
+    PathOnly,
+}
+
+pub fn terminal_cwd(target: &FileOpenTarget) -> PathBuf {
+    if target.is_dir {
+        return target.path.clone();
+    }
+
+    target
+        .path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| target.path.clone())
+}
+
+pub fn build_cli_location_command(
+    program: &str,
+    style: LocationStyle,
+    target: &FileOpenTarget,
+) -> OpenCommand {
+    let args = match style {
+        LocationStyle::GotoFlag => match location_arg(target) {
+            Some(location) => vec!["-g".to_string(), location],
+            None => vec![path_arg(&target.path)],
+        },
+        LocationStyle::PathSuffix => match location_arg(target) {
+            Some(location) => vec![location],
+            None => vec![path_arg(&target.path)],
+        },
+        LocationStyle::LineColumnFlags => {
+            let Some(line) = target.line else {
+                return OpenCommand {
+                    program: program.to_string(),
+                    args: vec![path_arg(&target.path)],
+                };
+            };
+
+            let mut args = vec!["--line".to_string(), line.to_string()];
+            if let Some(col) = target.col {
+                args.push("--column".to_string());
+                args.push(col.to_string());
+            }
+            args.push(path_arg(&target.path));
+            args
+        }
+        LocationStyle::PathOnly => vec![path_arg(&target.path)],
+    };
+
+    OpenCommand {
+        program: program.to_string(),
+        args,
+    }
+}
+
+pub fn build_finder_command(target: &FileOpenTarget) -> OpenCommand {
+    let path = path_arg(&target.path);
+    let args = if target.is_dir {
+        vec![path]
+    } else {
+        vec!["-R".to_string(), path]
+    };
+
+    OpenCommand {
+        program: "/usr/bin/open".to_string(),
+        args,
+    }
+}
+
+pub fn build_default_app_command(target: &FileOpenTarget) -> OpenCommand {
+    OpenCommand {
+        program: "/usr/bin/open".to_string(),
+        args: vec![path_arg(&target.path)],
+    }
+}
+
+pub fn build_wezterm_command(program: &str, target: &FileOpenTarget) -> OpenCommand {
+    OpenCommand {
+        program: program.to_string(),
+        args: vec![
+            "start".to_string(),
+            "--cwd".to_string(),
+            path_arg(&terminal_cwd(target)),
+        ],
+    }
+}
+
+const AUTO_FALLBACK_TARGETS: &[DefaultOpenTarget] = &[
+    DefaultOpenTarget::Cursor,
+    DefaultOpenTarget::Windsurf,
+    DefaultOpenTarget::Kiro,
+    DefaultOpenTarget::Antigravity,
+    DefaultOpenTarget::Zed,
+    DefaultOpenTarget::IntelliJIdea,
+    DefaultOpenTarget::VsCode,
+    DefaultOpenTarget::DefaultApp,
+    DefaultOpenTarget::Finder,
+];
+
+pub fn commands_for_target(
+    configured: DefaultOpenTarget,
+    target: &FileOpenTarget,
+) -> Vec<OpenCommand> {
+    match configured {
+        DefaultOpenTarget::Auto => Vec::new(),
+        DefaultOpenTarget::VsCode => editor_target_commands(
+            "code",
+            "Visual Studio Code",
+            LocationStyle::GotoFlag,
+            &[
+                "/usr/local/bin/code",
+                "/opt/homebrew/bin/code",
+                "/opt/local/bin/code",
+                "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+            ],
+            target,
+        ),
+        DefaultOpenTarget::Cursor => editor_target_commands(
+            "cursor",
+            "Cursor",
+            LocationStyle::GotoFlag,
+            &[
+                "/usr/local/bin/cursor",
+                "/opt/homebrew/bin/cursor",
+                "/opt/local/bin/cursor",
+                "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+            ],
+            target,
+        ),
+        DefaultOpenTarget::Windsurf => editor_target_commands(
+            "windsurf",
+            "Windsurf",
+            LocationStyle::GotoFlag,
+            &[
+                "/usr/local/bin/windsurf",
+                "/opt/homebrew/bin/windsurf",
+                "/opt/local/bin/windsurf",
+                "/Applications/Windsurf.app/Contents/Resources/app/bin/windsurf",
+            ],
+            target,
+        ),
+        DefaultOpenTarget::Kiro => editor_target_commands(
+            "kiro",
+            "Kiro",
+            LocationStyle::PathOnly,
+            &[
+                "/usr/local/bin/kiro",
+                "/opt/homebrew/bin/kiro",
+                "/opt/local/bin/kiro",
+                "/Applications/Kiro.app/Contents/Resources/app/bin/kiro",
+            ],
+            target,
+        ),
+        DefaultOpenTarget::Antigravity => antigravity_target_commands(target),
+        DefaultOpenTarget::Zed => editor_target_commands(
+            "zed",
+            "Zed",
+            LocationStyle::PathSuffix,
+            &[
+                "/usr/local/bin/zed",
+                "/opt/homebrew/bin/zed",
+                "/opt/local/bin/zed",
+                "/Applications/Zed.app/Contents/MacOS/cli",
+                "/Applications/Zed.app/Contents/MacOS/zed",
+            ],
+            target,
+        ),
+        DefaultOpenTarget::IntelliJIdea => editor_target_commands(
+            "idea",
+            "IntelliJ IDEA",
+            LocationStyle::LineColumnFlags,
+            &[
+                "/usr/local/bin/idea",
+                "/opt/homebrew/bin/idea",
+                "/opt/local/bin/idea",
+                "/Applications/IntelliJ IDEA.app/Contents/MacOS/idea",
+            ],
+            target,
+        ),
+        DefaultOpenTarget::DefaultApp => vec![build_default_app_command(target)],
+        DefaultOpenTarget::Finder => vec![build_finder_command(target)],
+        DefaultOpenTarget::Terminal => vec![build_terminal_app_command("Terminal", target)],
+        DefaultOpenTarget::ITerm2 => vec![build_terminal_app_command("iTerm", target)],
+        DefaultOpenTarget::Ghostty => vec![build_terminal_app_command("Ghostty", target)],
+        DefaultOpenTarget::WezTerm => wezterm_target_commands(target),
+        DefaultOpenTarget::Cmux => cmux_target_commands(target),
+    }
+}
+
+pub fn open_with_runner(
+    configured: DefaultOpenTarget,
+    target: &FileOpenTarget,
+    runner: &mut dyn CommandRunner,
+) -> anyhow::Result<()> {
+    open_with_runner_and_env(configured, target, EditorEnv::current(), runner)
+}
+
+fn open_with_runner_and_env(
+    configured: DefaultOpenTarget,
+    target: &FileOpenTarget,
+    env: EditorEnv,
+    runner: &mut dyn CommandRunner,
+) -> anyhow::Result<()> {
+    if configured == DefaultOpenTarget::Auto {
+        return open_auto_with_runner(target, env, runner);
+    }
+
+    let mut failed_commands = Vec::new();
+    for command in commands_for_target(configured, target) {
+        if runner.run(&command)? {
+            return Ok(());
+        }
+        failed_commands.push(command);
+    }
+
+    log::debug!(
+        "configured open target {} did not launch; falling back to auto",
+        configured.as_str()
+    );
+    open_auto_with_runner_skipping_failed_commands(
+        target,
+        env,
+        runner,
+        Some(configured),
+        &failed_commands,
+    )
+}
+
+pub fn open_auto_with_runner(
+    target: &FileOpenTarget,
+    env: EditorEnv,
+    runner: &mut dyn CommandRunner,
+) -> anyhow::Result<()> {
+    open_auto_with_runner_skipping(target, env, runner, None)
+}
+
+fn open_auto_with_runner_skipping(
+    target: &FileOpenTarget,
+    env: EditorEnv,
+    runner: &mut dyn CommandRunner,
+    skip: Option<DefaultOpenTarget>,
+) -> anyhow::Result<()> {
+    open_auto_with_runner_skipping_failed_commands(target, env, runner, skip, &[])
+}
+
+fn open_auto_with_runner_skipping_failed_commands(
+    target: &FileOpenTarget,
+    env: EditorEnv,
+    runner: &mut dyn CommandRunner,
+    skip: Option<DefaultOpenTarget>,
+    initial_failed_commands: &[OpenCommand],
+) -> anyhow::Result<()> {
+    let mut failed_commands = initial_failed_commands.to_vec();
+
+    for raw in [env.visual.as_deref(), env.editor.as_deref()]
+        .iter()
+        .copied()
+        .flatten()
+    {
+        match build_editor_env_command(raw, target) {
+            Ok(command) => {
+                if command_was_attempted(&command, &failed_commands)
+                    || skip.is_some_and(|configured| {
+                        command_targets_configured(&command, configured, target)
+                    })
+                {
+                    log::debug!(
+                        "skipping env editor command for failed configured open target: {:?}",
+                        command
+                    );
+                    continue;
+                }
+
+                if runner.run(&command)? {
+                    return Ok(());
+                }
+                failed_commands.push(command);
+            }
+            Err(err) => log::warn!("skipping invalid editor command `{raw}`: {err:#}"),
+        }
+    }
+
+    for configured in AUTO_FALLBACK_TARGETS {
+        if Some(*configured) == skip {
+            continue;
+        }
+
+        for command in commands_for_target(*configured, target) {
+            if command_was_attempted(&command, &failed_commands) {
+                log::debug!(
+                    "skipping repeated failed open target command: {:?}",
+                    command
+                );
+                continue;
+            }
+
+            if runner.run(&command)? {
+                return Ok(());
+            }
+            failed_commands.push(command);
+        }
+    }
+
+    anyhow::bail!("failed to open {}", target.path.display())
+}
+
+fn editor_target_commands(
+    cli_name: &str,
+    app_name: &str,
+    style: LocationStyle,
+    app_cli_paths: &[&str],
+    target: &FileOpenTarget,
+) -> Vec<OpenCommand> {
+    let mut commands = vec![build_cli_location_command(cli_name, style, target)];
+
+    for cli_path in app_cli_paths {
+        commands.push(build_cli_location_command(cli_path, style, target));
+        if let Some(user_cli_path) = user_application_cli_path(cli_path) {
+            commands.push(build_cli_location_command(&user_cli_path, style, target));
+        }
+    }
+
+    commands.push(build_open_app_command(app_name, target));
+    commands
+}
+
+fn antigravity_target_commands(target: &FileOpenTarget) -> Vec<OpenCommand> {
+    let style = LocationStyle::GotoFlag;
+    let mut commands = vec![build_cli_location_command("antigravity", style, target)];
+
+    if let Some(cli_path) = home_relative_cli_path(".antigravity/antigravity/bin/antigravity") {
+        commands.push(build_cli_location_command(&cli_path, style, target));
+    }
+
+    for cli_path in [
+        "/usr/local/bin/antigravity",
+        "/opt/homebrew/bin/antigravity",
+        "/opt/local/bin/antigravity",
+        "/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity",
+    ] {
+        commands.push(build_cli_location_command(cli_path, style, target));
+        if let Some(user_cli_path) = user_application_cli_path(cli_path) {
+            commands.push(build_cli_location_command(&user_cli_path, style, target));
+        }
+    }
+
+    commands.push(build_open_app_command("Antigravity", target));
+    commands
+}
+
+fn build_open_app_command(app_name: &str, target: &FileOpenTarget) -> OpenCommand {
+    OpenCommand {
+        program: "/usr/bin/open".to_string(),
+        args: vec![
+            "-a".to_string(),
+            app_name.to_string(),
+            path_arg(&target.path),
+        ],
+    }
+}
+
+fn build_terminal_path_command(program: &str, target: &FileOpenTarget) -> OpenCommand {
+    OpenCommand {
+        program: program.to_string(),
+        args: vec![path_arg(&terminal_cwd(target))],
+    }
+}
+
+fn wezterm_target_commands(target: &FileOpenTarget) -> Vec<OpenCommand> {
+    let mut commands = vec![build_wezterm_command("wezterm", target)];
+
+    for cli_path in [
+        "/usr/local/bin/wezterm",
+        "/opt/homebrew/bin/wezterm",
+        "/opt/local/bin/wezterm",
+        "/Applications/WezTerm.app/Contents/MacOS/wezterm",
+    ] {
+        commands.push(build_wezterm_command(cli_path, target));
+        if let Some(user_cli_path) = user_application_cli_path(cli_path) {
+            commands.push(build_wezterm_command(&user_cli_path, target));
+        }
+    }
+
+    commands.push(build_terminal_app_command("WezTerm", target));
+    commands
+}
+
+fn cmux_target_commands(target: &FileOpenTarget) -> Vec<OpenCommand> {
+    let mut commands = vec![build_terminal_path_command("cmux", target)];
+
+    for cli_path in [
+        "/usr/local/bin/cmux",
+        "/opt/homebrew/bin/cmux",
+        "/opt/local/bin/cmux",
+        "/Applications/cmux.app/Contents/Resources/bin/cmux",
+        "/Applications/cmux.app/Contents/MacOS/cmux",
+    ] {
+        commands.push(build_terminal_path_command(cli_path, target));
+        if let Some(user_cli_path) = user_application_cli_path(cli_path) {
+            commands.push(build_terminal_path_command(&user_cli_path, target));
+        }
+    }
+
+    commands.push(build_terminal_app_command("cmux", target));
+    commands
+}
+
+fn build_terminal_app_command(app_name: &str, target: &FileOpenTarget) -> OpenCommand {
+    OpenCommand {
+        program: "/usr/bin/open".to_string(),
+        args: vec![
+            "-a".to_string(),
+            app_name.to_string(),
+            path_arg(&terminal_cwd(target)),
+        ],
+    }
+}
+
+fn home_relative_cli_path(relative: &str) -> Option<String> {
+    Some(
+        PathBuf::from(std::env::var_os("HOME")?)
+            .join(relative)
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+fn user_application_cli_path(canonical_cli_path: &str) -> Option<String> {
+    let home = std::env::var_os("HOME")?;
+    let relative = Path::new(canonical_cli_path)
+        .strip_prefix("/Applications")
+        .ok()?;
+
+    Some(
+        PathBuf::from(home)
+            .join("Applications")
+            .join(relative)
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+fn build_editor_env_command(raw: &str, target: &FileOpenTarget) -> anyhow::Result<OpenCommand> {
+    let mut parts = shlex::split(raw.trim()).context("invalid shell quoting")?;
+    anyhow::ensure!(!parts.is_empty(), "editor command is empty");
+    let program = parts.remove(0);
+    parts.push(path_arg(&target.path));
+
+    Ok(OpenCommand {
+        program,
+        args: parts,
+    })
+}
+
+fn command_targets_configured(
+    command: &OpenCommand,
+    configured: DefaultOpenTarget,
+    target: &FileOpenTarget,
+) -> bool {
+    let program_name = command_program_name(command);
+
+    if program_name != "open"
+        && commands_for_target(configured, &skip_probe_target())
+            .iter()
+            .any(|target_command| {
+                target_command.program == command.program
+                    && command_program_name(target_command) != "open"
+            })
+    {
+        return true;
+    }
+
+    match configured {
+        DefaultOpenTarget::DefaultApp => return command_opens_default_app(command, target),
+        DefaultOpenTarget::Finder => return command_reveals_in_finder(command, target),
+        _ => {}
+    }
+
+    let Some(app_name) = target_app_name(configured) else {
+        return false;
+    };
+
+    program_name == "open"
+        && command.args.len() >= 2
+        && command.args[0] == "-a"
+        && command.args[1] == app_name
+}
+
+fn command_was_attempted(command: &OpenCommand, attempted: &[OpenCommand]) -> bool {
+    attempted.iter().any(|attempted| attempted == command)
+}
+
+fn command_opens_default_app(command: &OpenCommand, target: &FileOpenTarget) -> bool {
+    let path = path_arg(&target.path);
+
+    command_program_name(command) == "open" && command.args.len() == 1 && command.args[0] == path
+}
+
+fn command_reveals_in_finder(command: &OpenCommand, target: &FileOpenTarget) -> bool {
+    let path = path_arg(&target.path);
+
+    command_program_name(command) == "open"
+        && command.args.len() == 2
+        && command.args[0] == "-R"
+        && command.args[1] == path
+}
+
+fn command_program_name(command: &OpenCommand) -> &str {
+    Path::new(&command.program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(command.program.as_str())
+}
+
+fn skip_probe_target() -> FileOpenTarget {
+    FileOpenTarget {
+        path: PathBuf::from("/tmp/kaku-open-target-probe"),
+        line: Some(1),
+        col: Some(1),
+        is_dir: false,
+    }
+}
+
+fn target_app_name(configured: DefaultOpenTarget) -> Option<&'static str> {
+    match configured {
+        DefaultOpenTarget::VsCode => Some("Visual Studio Code"),
+        DefaultOpenTarget::Cursor => Some("Cursor"),
+        DefaultOpenTarget::Windsurf => Some("Windsurf"),
+        DefaultOpenTarget::Kiro => Some("Kiro"),
+        DefaultOpenTarget::Antigravity => Some("Antigravity"),
+        DefaultOpenTarget::Zed => Some("Zed"),
+        DefaultOpenTarget::IntelliJIdea => Some("IntelliJ IDEA"),
+        DefaultOpenTarget::Terminal => Some("Terminal"),
+        DefaultOpenTarget::ITerm2 => Some("iTerm"),
+        DefaultOpenTarget::Ghostty => Some("Ghostty"),
+        DefaultOpenTarget::WezTerm => Some("WezTerm"),
+        DefaultOpenTarget::Cmux => Some("cmux"),
+        _ => None,
+    }
+}
+
+fn location_arg(target: &FileOpenTarget) -> Option<String> {
+    let line = target.line?;
+    let mut location = format!("{}:{}", path_arg(&target.path), line);
+
+    if let Some(col) = target.col {
+        location.push(':');
+        location.push_str(&col.to_string());
+    }
+
+    Some(location)
+}
+
+fn path_arg(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config::DefaultOpenTarget;
+    use std::collections::VecDeque;
+
+    #[derive(Default)]
+    struct FakeRunner {
+        results: VecDeque<anyhow::Result<bool>>,
+        successes: Vec<OpenCommand>,
+        attempts: Vec<OpenCommand>,
+    }
+
+    impl FakeRunner {
+        fn new(results: impl IntoIterator<Item = anyhow::Result<bool>>) -> Self {
+            Self {
+                results: results.into_iter().collect(),
+                successes: Vec::new(),
+                attempts: Vec::new(),
+            }
+        }
+
+        fn with_successes(successes: impl IntoIterator<Item = OpenCommand>) -> Self {
+            Self {
+                results: VecDeque::new(),
+                successes: successes.into_iter().collect(),
+                attempts: Vec::new(),
+            }
+        }
+    }
+
+    impl CommandRunner for FakeRunner {
+        fn run(&mut self, command: &OpenCommand) -> anyhow::Result<bool> {
+            self.attempts.push(command.clone());
+            if let Some(result) = self.results.pop_front() {
+                return result;
+            }
+
+            Ok(self.successes.iter().any(|success| success == command))
+        }
+    }
+
+    fn file_target() -> FileOpenTarget {
+        FileOpenTarget {
+            path: PathBuf::from("/tmp/project/src/main.rs"),
+            line: Some(12),
+            col: Some(4),
+            is_dir: false,
+        }
+    }
+
+    fn dir_target() -> FileOpenTarget {
+        FileOpenTarget {
+            path: PathBuf::from("/tmp/project"),
+            line: None,
+            col: None,
+            is_dir: true,
+        }
+    }
+
+    #[test]
+    fn terminal_targets_open_file_parent_directory() {
+        assert_eq!(
+            terminal_cwd(&file_target()),
+            PathBuf::from("/tmp/project/src")
+        );
+    }
+
+    #[test]
+    fn terminal_targets_open_directory_itself() {
+        assert_eq!(terminal_cwd(&dir_target()), PathBuf::from("/tmp/project"));
+    }
+
+    #[test]
+    fn terminal_targets_fall_back_to_path_when_file_has_no_parent() {
+        let target = FileOpenTarget {
+            path: PathBuf::from("main.rs"),
+            line: None,
+            col: None,
+            is_dir: false,
+        };
+
+        assert_eq!(terminal_cwd(&target), PathBuf::from("main.rs"));
+    }
+
+    #[test]
+    fn vscode_style_goto_command_includes_g_flag_and_location() {
+        let command = build_cli_location_command("code", LocationStyle::GotoFlag, &file_target());
+
+        assert_eq!(command.program, "code");
+        assert_eq!(
+            command.args,
+            vec![
+                "-g".to_string(),
+                "/tmp/project/src/main.rs:12:4".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn zed_style_suffix_command_includes_location() {
+        let command = build_cli_location_command("zed", LocationStyle::PathSuffix, &file_target());
+
+        assert_eq!(command.program, "zed");
+        assert_eq!(
+            command.args,
+            vec!["/tmp/project/src/main.rs:12:4".to_string()]
+        );
+    }
+
+    #[test]
+    fn intellij_style_command_includes_line_and_column_flags() {
+        let command =
+            build_cli_location_command("idea", LocationStyle::LineColumnFlags, &file_target());
+
+        assert_eq!(command.program, "idea");
+        assert_eq!(
+            command.args,
+            vec![
+                "--line".to_string(),
+                "12".to_string(),
+                "--column".to_string(),
+                "4".to_string(),
+                "/tmp/project/src/main.rs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn goto_command_without_line_uses_bare_path() {
+        let target = FileOpenTarget {
+            path: PathBuf::from("/tmp/project/src/main.rs"),
+            line: None,
+            col: Some(4),
+            is_dir: false,
+        };
+
+        let command = build_cli_location_command("code", LocationStyle::GotoFlag, &target);
+
+        assert_eq!(command.args, vec!["/tmp/project/src/main.rs".to_string()]);
+    }
+
+    #[test]
+    fn suffix_command_without_line_uses_bare_path() {
+        let target = FileOpenTarget {
+            path: PathBuf::from("/tmp/project/src/main.rs"),
+            line: None,
+            col: Some(4),
+            is_dir: false,
+        };
+
+        let command = build_cli_location_command("zed", LocationStyle::PathSuffix, &target);
+
+        assert_eq!(command.args, vec!["/tmp/project/src/main.rs".to_string()]);
+    }
+
+    #[test]
+    fn line_column_command_without_line_uses_bare_path() {
+        let target = FileOpenTarget {
+            path: PathBuf::from("/tmp/project/src/main.rs"),
+            line: None,
+            col: Some(4),
+            is_dir: false,
+        };
+
+        let command = build_cli_location_command("idea", LocationStyle::LineColumnFlags, &target);
+
+        assert_eq!(command.args, vec!["/tmp/project/src/main.rs".to_string()]);
+    }
+
+    #[test]
+    fn path_only_command_uses_bare_path_even_with_line() {
+        let command = build_cli_location_command("editor", LocationStyle::PathOnly, &file_target());
+
+        assert_eq!(command.program, "editor");
+        assert_eq!(command.args, vec!["/tmp/project/src/main.rs".to_string()]);
+    }
+
+    #[test]
+    fn finder_reveals_files() {
+        let command = build_finder_command(&file_target());
+
+        assert_eq!(command.program, "/usr/bin/open");
+        assert_eq!(
+            command.args,
+            vec!["-R".to_string(), "/tmp/project/src/main.rs".to_string()]
+        );
+    }
+
+    #[test]
+    fn finder_opens_directories() {
+        let command = build_finder_command(&dir_target());
+
+        assert_eq!(command.program, "/usr/bin/open");
+        assert_eq!(command.args, vec!["/tmp/project".to_string()]);
+    }
+
+    #[test]
+    fn default_app_opens_target_path() {
+        let command = build_default_app_command(&file_target());
+
+        assert_eq!(command.program, "/usr/bin/open");
+        assert_eq!(command.args, vec!["/tmp/project/src/main.rs".to_string()]);
+    }
+
+    #[test]
+    fn editor_target_commands_include_app_bundle_cli_and_open_app_fallback() {
+        let commands = commands_for_target(DefaultOpenTarget::Cursor, &file_target());
+
+        assert!(commands.iter().any(|command| command.program
+            == "/Applications/Cursor.app/Contents/Resources/app/bin/cursor"));
+        assert!(commands
+            .iter()
+            .any(|command| command.program == "/usr/bin/open"
+                && command.args
+                    == vec![
+                        "-a".to_string(),
+                        "Cursor".to_string(),
+                        "/tmp/project/src/main.rs".to_string(),
+                    ]));
+    }
+
+    #[test]
+    fn vscode_commands_include_legacy_app_bundle_cli_path() {
+        let commands = commands_for_target(DefaultOpenTarget::VsCode, &file_target());
+
+        assert!(commands.iter().any(|command| command.program
+            == "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"));
+    }
+
+    #[test]
+    fn antigravity_commands_use_goto_location_and_home_cli_path() {
+        let commands = commands_for_target(DefaultOpenTarget::Antigravity, &file_target());
+
+        assert_eq!(commands[0].program, "antigravity");
+        assert_eq!(
+            commands[0].args,
+            vec![
+                "-g".to_string(),
+                "/tmp/project/src/main.rs:12:4".to_string()
+            ]
+        );
+        assert!(commands.iter().any(|command| command.program
+            == format!(
+                "{}/.antigravity/antigravity/bin/antigravity",
+                std::env::var("HOME").expect("HOME")
+            )
+            && command.args
+                == vec![
+                    "-g".to_string(),
+                    "/tmp/project/src/main.rs:12:4".to_string(),
+                ]));
+    }
+
+    #[test]
+    fn intellij_commands_use_line_column_location() {
+        let command = commands_for_target(DefaultOpenTarget::IntelliJIdea, &file_target())
+            .into_iter()
+            .next()
+            .unwrap();
+
+        assert_eq!(command.program, "idea");
+        assert_eq!(
+            command.args,
+            vec![
+                "--line".to_string(),
+                "12".to_string(),
+                "--column".to_string(),
+                "4".to_string(),
+                "/tmp/project/src/main.rs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn wezterm_uses_start_with_cwd() {
+        let command = build_wezterm_command("wezterm", &file_target());
+
+        assert_eq!(command.program, "wezterm");
+        assert_eq!(
+            command.args,
+            vec![
+                "start".to_string(),
+                "--cwd".to_string(),
+                "/tmp/project/src".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn wezterm_target_commands_include_app_bundle_cli_and_open_app_fallback() {
+        let commands = commands_for_target(DefaultOpenTarget::WezTerm, &file_target());
+
+        assert!(commands
+            .iter()
+            .any(|command| command.program == "/Applications/WezTerm.app/Contents/MacOS/wezterm"));
+        assert!(commands
+            .iter()
+            .any(|command| command.program == "/usr/bin/open"
+                && command.args
+                    == vec![
+                        "-a".to_string(),
+                        "WezTerm".to_string(),
+                        "/tmp/project/src".to_string(),
+                    ]));
+    }
+
+    #[test]
+    fn cmux_target_commands_include_absolute_cli_and_open_app_fallback() {
+        let commands = commands_for_target(DefaultOpenTarget::Cmux, &file_target());
+
+        assert!(commands
+            .iter()
+            .any(|command| command.program == "/usr/local/bin/cmux"
+                && command.args == vec!["/tmp/project/src".to_string()]));
+        assert!(commands.iter().any(|command| command.program
+            == "/Applications/cmux.app/Contents/Resources/bin/cmux"
+            && command.args == vec!["/tmp/project/src".to_string()]));
+        assert!(commands
+            .iter()
+            .any(|command| command.program == "/usr/bin/open"
+                && command.args
+                    == vec![
+                        "-a".to_string(),
+                        "cmux".to_string(),
+                        "/tmp/project/src".to_string(),
+                    ]));
+    }
+
+    #[test]
+    fn selected_missing_target_falls_back_to_default_app_without_retrying_selected_target() {
+        let target = file_target();
+        let mut runner = FakeRunner::with_successes([build_default_app_command(&target)]);
+
+        open_with_runner(DefaultOpenTarget::Cursor, &target, &mut runner).unwrap();
+
+        assert_eq!(runner.attempts[0].program, "cursor");
+        assert_eq!(
+            runner
+                .attempts
+                .iter()
+                .filter(|command| command.program == "cursor")
+                .count(),
+            1
+        );
+        assert_eq!(
+            runner
+                .attempts
+                .iter()
+                .filter(|command| command.program == "/usr/bin/open"
+                    && command
+                        .args
+                        .starts_with(&["-a".to_string(), "Cursor".to_string()]))
+                .count(),
+            1
+        );
+        assert!(runner
+            .attempts
+            .iter()
+            .any(|command| command == &build_default_app_command(&target)));
+    }
+
+    #[test]
+    fn auto_tries_editor_env_before_default_app() {
+        let mut runner = FakeRunner::new([Ok(true)]);
+
+        open_auto_with_runner(
+            &file_target(),
+            EditorEnv {
+                visual: Some("vim".to_string()),
+                editor: None,
+            },
+            &mut runner,
+        )
+        .unwrap();
+
+        assert_eq!(
+            runner.attempts[0],
+            OpenCommand {
+                program: "vim".to_string(),
+                args: vec!["/tmp/project/src/main.rs".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn selected_target_fallback_skips_matching_env_editor_command() {
+        let target = file_target();
+        let mut runner = FakeRunner::with_successes([build_default_app_command(&target)]);
+
+        open_auto_with_runner_skipping(
+            &target,
+            EditorEnv {
+                visual: Some("cursor".to_string()),
+                editor: None,
+            },
+            &mut runner,
+            Some(DefaultOpenTarget::Cursor),
+        )
+        .unwrap();
+
+        assert!(!runner
+            .attempts
+            .iter()
+            .any(|command| command.program == "cursor"));
+        assert!(runner
+            .attempts
+            .iter()
+            .any(|command| command == &build_default_app_command(&target)));
+    }
+
+    #[test]
+    fn selected_target_fallback_skips_matching_env_open_app_command() {
+        let target = file_target();
+        let mut runner = FakeRunner::with_successes([build_default_app_command(&target)]);
+
+        open_auto_with_runner_skipping(
+            &target,
+            EditorEnv {
+                visual: Some("/usr/bin/open -a Cursor".to_string()),
+                editor: None,
+            },
+            &mut runner,
+            Some(DefaultOpenTarget::Cursor),
+        )
+        .unwrap();
+
+        assert!(!runner
+            .attempts
+            .iter()
+            .any(|command| command.program == "/usr/bin/open"
+                && command
+                    .args
+                    .starts_with(&["-a".to_string(), "Cursor".to_string()])));
+        assert!(runner
+            .attempts
+            .iter()
+            .any(|command| command == &build_default_app_command(&target)));
+    }
+
+    #[test]
+    fn selected_target_fallback_skips_matching_env_app_cli_command() {
+        let target = file_target();
+        let mut runner = FakeRunner::with_successes([build_default_app_command(&target)]);
+
+        open_auto_with_runner_skipping(
+            &target,
+            EditorEnv {
+                visual: Some("/Applications/Zed.app/Contents/MacOS/cli".to_string()),
+                editor: None,
+            },
+            &mut runner,
+            Some(DefaultOpenTarget::Zed),
+        )
+        .unwrap();
+
+        assert!(!runner
+            .attempts
+            .iter()
+            .any(|command| command.program == "/Applications/Zed.app/Contents/MacOS/cli"));
+        assert!(runner
+            .attempts
+            .iter()
+            .any(|command| command == &build_default_app_command(&target)));
+    }
+
+    #[test]
+    fn selected_default_app_fallback_skips_matching_env_open_command() {
+        let target = file_target();
+        let env_open = OpenCommand {
+            program: "open".to_string(),
+            args: vec!["/tmp/project/src/main.rs".to_string()],
+        };
+        let mut runner = FakeRunner::with_successes([build_finder_command(&target)]);
+
+        open_auto_with_runner_skipping(
+            &target,
+            EditorEnv {
+                visual: Some("open".to_string()),
+                editor: None,
+            },
+            &mut runner,
+            Some(DefaultOpenTarget::DefaultApp),
+        )
+        .unwrap();
+
+        assert!(!runner.attempts.iter().any(|command| command == &env_open));
+        assert!(runner
+            .attempts
+            .iter()
+            .any(|command| command == &build_finder_command(&target)));
+    }
+
+    #[test]
+    fn selected_finder_fallback_skips_matching_env_open_reveal_command() {
+        let target = file_target();
+        let env_finder = OpenCommand {
+            program: "open".to_string(),
+            args: vec!["-R".to_string(), "/tmp/project/src/main.rs".to_string()],
+        };
+        let mut runner = FakeRunner::with_successes([build_default_app_command(&target)]);
+
+        open_auto_with_runner_skipping(
+            &target,
+            EditorEnv {
+                visual: Some("open -R".to_string()),
+                editor: None,
+            },
+            &mut runner,
+            Some(DefaultOpenTarget::Finder),
+        )
+        .unwrap();
+
+        assert!(!runner.attempts.iter().any(|command| command == &env_finder));
+        assert!(runner
+            .attempts
+            .iter()
+            .any(|command| command == &build_default_app_command(&target)));
+    }
+
+    #[test]
+    fn selected_finder_directory_fallback_skips_duplicate_default_app_command() {
+        let target = dir_target();
+        let duplicate = build_default_app_command(&target);
+        let mut runner = FakeRunner::with_successes([]);
+
+        open_with_runner_and_env(
+            DefaultOpenTarget::Finder,
+            &target,
+            EditorEnv::default(),
+            &mut runner,
+        )
+        .expect_err("all fallback commands should fail");
+
+        assert_eq!(
+            runner
+                .attempts
+                .iter()
+                .filter(|command| *command == &duplicate)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn selected_default_app_directory_fallback_skips_duplicate_finder_command() {
+        let target = dir_target();
+        let duplicate = build_finder_command(&target);
+        let mut runner = FakeRunner::with_successes([]);
+
+        open_with_runner_and_env(
+            DefaultOpenTarget::DefaultApp,
+            &target,
+            EditorEnv::default(),
+            &mut runner,
+        )
+        .expect_err("all fallback commands should fail");
+
+        assert_eq!(
+            runner
+                .attempts
+                .iter()
+                .filter(|command| *command == &duplicate)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn auto_fallback_skips_env_command_after_it_fails() {
+        let target = dir_target();
+        let duplicate = build_default_app_command(&target);
+        let mut runner = FakeRunner::with_successes([]);
+
+        open_auto_with_runner(
+            &target,
+            EditorEnv {
+                visual: Some("/usr/bin/open".to_string()),
+                editor: None,
+            },
+            &mut runner,
+        )
+        .expect_err("all fallback commands should fail");
+
+        assert_eq!(
+            runner
+                .attempts
+                .iter()
+                .filter(|command| *command == &duplicate)
+                .count(),
+            1
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_runner_treats_launch_errors_as_command_failures() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let launcher = dir.path().join("not-executable");
+        std::fs::write(&launcher, "#!/bin/sh\nexit 0\n").expect("write launcher");
+        std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o644))
+            .expect("set permissions");
+        let command = OpenCommand {
+            program: launcher.to_string_lossy().into_owned(),
+            args: Vec::new(),
+        };
+        let mut runner = ProcessCommandRunner;
+
+        assert!(!runner.run(&command).expect("launch failure is non-fatal"));
+    }
+
+    #[test]
+    fn selected_target_fallback_keeps_unrelated_env_open_app_command() {
+        let target = file_target();
+        let textedit = OpenCommand {
+            program: "/usr/bin/open".to_string(),
+            args: vec![
+                "-a".to_string(),
+                "TextEdit".to_string(),
+                "/tmp/project/src/main.rs".to_string(),
+            ],
+        };
+        let mut runner = FakeRunner::with_successes([textedit.clone()]);
+
+        open_auto_with_runner_skipping(
+            &target,
+            EditorEnv {
+                visual: Some("/usr/bin/open -a TextEdit".to_string()),
+                editor: None,
+            },
+            &mut runner,
+            Some(DefaultOpenTarget::Zed),
+        )
+        .unwrap();
+
+        assert_eq!(runner.attempts, vec![textedit]);
+    }
+
+    #[test]
+    fn selected_non_auto_success_does_not_fall_through_to_default_app() {
+        let mut runner = FakeRunner::new([Ok(true)]);
+
+        open_with_runner(DefaultOpenTarget::Zed, &file_target(), &mut runner).unwrap();
+
+        assert_eq!(runner.attempts.len(), 1);
+        assert_eq!(runner.attempts[0].program, "zed");
+    }
+
+    #[test]
+    fn auto_returns_error_when_no_command_succeeds() {
+        let mut runner = FakeRunner::new(std::iter::repeat_with(|| Ok(false)).take(16));
+
+        let err = open_auto_with_runner(&file_target(), EditorEnv::default(), &mut runner)
+            .expect_err("auto should fail when every command fails");
+
+        assert!(err
+            .to_string()
+            .contains("failed to open /tmp/project/src/main.rs"));
+    }
+
+    #[test]
+    fn terminal_target_uses_open_app_with_terminal_cwd() {
+        let command = commands_for_target(DefaultOpenTarget::Terminal, &file_target())
+            .into_iter()
+            .next()
+            .unwrap();
+
+        assert_eq!(command.program, "/usr/bin/open");
+        assert_eq!(
+            command.args,
+            vec![
+                "-a".to_string(),
+                "Terminal".to_string(),
+                "/tmp/project/src".to_string()
+            ]
+        );
+    }
+}

--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -58,7 +58,6 @@ use std::cell::{RefCell, RefMut};
 use std::collections::{HashMap, LinkedList};
 use std::ops::Add;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -149,14 +148,6 @@ use crate::spawn::SpawnWhere;
 use prevcursor::PrevCursorPos;
 
 const ATLAS_SIZE: usize = 128;
-const VSCODE_OPEN_CANDIDATES: &[&str] = &[
-    "code",
-    "/usr/local/bin/code",
-    "/opt/homebrew/bin/code",
-    "/opt/local/bin/code",
-    "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
-];
-
 const TOP_TAB_LAYOUT_FULLSCREEN_STICKY_MS: u64 = 160;
 
 #[derive(Clone, Debug)]
@@ -4918,154 +4909,19 @@ impl TermWindow {
     }
 
     fn open_file_link_target(target: &FileLinkTarget) -> anyhow::Result<()> {
-        if target.path.is_file() && Self::try_open_file_in_vscode(target)? {
-            return Ok(());
-        }
-
-        if Self::try_open_in_configured_editor(&target.path)? {
-            return Ok(());
-        }
-
-        if Self::try_open_path_in_vscode(&target.path)? {
-            return Ok(());
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            if Self::try_open_path_with_default_app(&target.path)? {
-                return Ok(());
-            }
-
-            if target.path.is_file() && Self::try_open_text(&target.path)? {
-                return Ok(());
-            }
-
-            if target.path.is_file() && Self::try_reveal_in_finder(&target.path)? {
-                return Ok(());
-            }
-        }
-
-        anyhow::bail!("failed to open {}", target.path.display())
-    }
-
-    fn try_open_file_in_vscode(target: &FileLinkTarget) -> anyhow::Result<bool> {
-        let Some(line) = target.line else {
-            return Ok(false);
+        let open_target = crate::open_target::FileOpenTarget {
+            path: target.path.clone(),
+            line: target.line,
+            col: target.col,
+            is_dir: target.path.is_dir(),
         };
 
-        let mut location = format!("{}:{line}", target.path.display());
-        if let Some(col) = target.col {
-            location.push(':');
-            location.push_str(&col.to_string());
-        }
-
-        for candidate in VSCODE_OPEN_CANDIDATES {
-            let result = std::process::Command::new(candidate)
-                .arg("-g")
-                .arg(&location)
-                .status();
-
-            match result {
-                Ok(status) if status.success() => return Ok(true),
-                Ok(_) => return Ok(false),
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
-                Err(err) => return Err(err.into()),
-            }
-        }
-
-        Ok(false)
-    }
-
-    fn try_open_in_configured_editor(path: &Path) -> anyhow::Result<bool> {
-        for var in ["VISUAL", "EDITOR"] {
-            if Self::try_open_in_env_editor(var, path)? {
-                return Ok(true);
-            }
-        }
-
-        Ok(false)
-    }
-
-    fn try_open_in_env_editor(var: &str, path: &Path) -> anyhow::Result<bool> {
-        let Some(raw) = std::env::var_os(var) else {
-            return Ok(false);
-        };
-
-        let raw = raw.to_string_lossy();
-        let (program, args) =
-            Self::parse_editor_command(raw.trim()).with_context(|| format!("parse ${var}"))?;
-
-        Self::run_path_command(&program, &args, path)
-            .with_context(|| format!("launch ${var} editor `{program}`"))?;
-        Ok(true)
-    }
-
-    fn parse_editor_command(raw: &str) -> anyhow::Result<(String, Vec<String>)> {
-        let parts = shlex::split(raw).context("invalid shell quoting")?;
-        let Some((program, args)) = parts.split_first() else {
-            anyhow::bail!("editor command is empty");
-        };
-        Ok((program.clone(), args.to_vec()))
-    }
-
-    fn try_open_path_in_vscode(path: &Path) -> anyhow::Result<bool> {
-        for candidate in VSCODE_OPEN_CANDIDATES {
-            let result = Command::new(candidate).arg(path).status();
-
-            match result {
-                Ok(status) if status.success() => return Ok(true),
-                Ok(_) => return Ok(false),
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
-                Err(err) => return Err(err.into()),
-            }
-        }
-
-        Ok(false)
-    }
-
-    #[cfg(target_os = "macos")]
-    fn try_open_text(path: &Path) -> anyhow::Result<bool> {
-        match Self::run_path_command("/usr/bin/open", &["-t".to_string()], path) {
-            Ok(()) => Ok(true),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(err) => Err(err).context("launch macOS text editor"),
-        }
-    }
-
-    #[cfg(target_os = "macos")]
-    fn try_open_path_with_default_app(path: &Path) -> anyhow::Result<bool> {
-        match Self::run_path_command("/usr/bin/open", &[], path) {
-            Ok(()) => Ok(true),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(err) => Err(err).context("launch default app"),
-        }
-    }
-
-    #[cfg(target_os = "macos")]
-    fn try_reveal_in_finder(path: &Path) -> anyhow::Result<bool> {
-        match Self::run_path_command("/usr/bin/open", &["-R".to_string()], path) {
-            Ok(()) => Ok(true),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(err) => Err(err).context("reveal file in Finder"),
-        }
-    }
-
-    fn run_path_command(program: &str, args: &[String], path: &Path) -> std::io::Result<()> {
-        let status = Command::new(program)
-            .args(args)
-            .arg(path)
-            .stdin(Stdio::inherit())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .status()?;
-
-        if status.success() {
-            return Ok(());
-        }
-
-        Err(std::io::Error::other(format!(
-            "`{program}` exited with status {status}"
-        )))
+        let mut runner = crate::open_target::ProcessCommandRunner;
+        crate::open_target::open_with_runner(
+            config::configuration().default_open_target,
+            &open_target,
+            &mut runner,
+        )
     }
 
     fn parse_file_location(path: &str) -> (String, Option<usize>, Option<usize>) {
@@ -6002,20 +5858,6 @@ mod tests {
         assert_eq!(path, "/tmp/demo.rs");
         assert_eq!(line, None);
         assert_eq!(col, None);
-    }
-
-    #[test]
-    fn parse_editor_command_extracts_program_and_flags() {
-        let (program, args) =
-            TermWindow::parse_editor_command(r#"code -g "/tmp/demo.rs:12:3""#).unwrap();
-        assert_eq!(program, "code");
-        assert_eq!(args, vec!["-g", "/tmp/demo.rs:12:3"]);
-    }
-
-    #[test]
-    fn parse_editor_command_rejects_empty_value() {
-        let err = TermWindow::parse_editor_command("   ").unwrap_err();
-        assert!(err.to_string().contains("editor command is empty"));
     }
 
     #[test]

--- a/kaku/src/config_tui/mod.rs
+++ b/kaku/src/config_tui/mod.rs
@@ -241,6 +241,29 @@ enum Mode {
     Selecting,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ConfigOption {
+    label: &'static str,
+    enabled: bool,
+}
+
+impl ConfigOption {
+    fn enabled(label: &'static str) -> Self {
+        Self {
+            label,
+            enabled: true,
+        }
+    }
+
+    #[cfg(test)]
+    fn disabled(label: &'static str) -> Self {
+        Self {
+            label,
+            enabled: false,
+        }
+    }
+}
+
 #[derive(Clone)]
 struct ConfigField {
     section: &'static str,
@@ -248,7 +271,7 @@ struct ConfigField {
     lua_key: &'static str,
     value: String,
     default: String,
-    options: Vec<&'static str>,
+    options: Vec<ConfigOption>,
     /// If true, the field's config line exists but could not be fully parsed.
     /// save_config will leave the line untouched to avoid corrupting user config.
     skip_write: bool,
@@ -257,6 +280,14 @@ struct ConfigField {
 impl ConfigField {
     fn has_options(&self) -> bool {
         !self.options.is_empty()
+    }
+
+    fn option_enabled(&self, label: &str) -> bool {
+        self.options
+            .iter()
+            .find(|option| option.label == label)
+            .map(|option| option.enabled)
+            .unwrap_or(false)
     }
 }
 
@@ -287,7 +318,11 @@ impl App {
                 lua_key: "color_scheme",
                 value: String::new(),
                 default: "Auto".into(),
-                options: vec!["Auto", "Kaku Dark", "Kaku Light"],
+                options: vec![
+                    ConfigOption::enabled("Auto"),
+                    ConfigOption::enabled("Kaku Dark"),
+                    ConfigOption::enabled("Kaku Light"),
+                ],
                 skip_write: false,
             },
             ConfigField {
@@ -327,12 +362,29 @@ impl App {
                 skip_write: false,
             },
             ConfigField {
+                section: "Integrations",
+                key: "Default Open Target",
+                lua_key: "default_open_target",
+                value: String::new(),
+                default: "Auto".into(),
+                options: vec![
+                    ConfigOption::enabled("Auto"),
+                    ConfigOption::enabled("Default app"),
+                    ConfigOption::enabled("Finder"),
+                    ConfigOption::enabled("Terminal"),
+                ],
+                skip_write: false,
+            },
+            ConfigField {
                 section: "Window",
                 key: "Tab Bar Position",
                 lua_key: "tab_bar_at_bottom",
                 value: String::new(),
                 default: "Bottom".into(),
-                options: vec!["Bottom", "Top"],
+                options: vec![
+                    ConfigOption::enabled("Bottom"),
+                    ConfigOption::enabled("Top"),
+                ],
                 skip_write: false,
             },
             ConfigField {
@@ -341,7 +393,7 @@ impl App {
                 lua_key: "tab_title_show_basename_only",
                 value: String::new(),
                 default: "Off".into(),
-                options: vec!["On", "Off"],
+                options: vec![ConfigOption::enabled("On"), ConfigOption::enabled("Off")],
                 skip_write: false,
             },
             ConfigField {
@@ -350,7 +402,7 @@ impl App {
                 lua_key: "enable_scroll_bar",
                 value: String::new(),
                 default: "Off".into(),
-                options: vec!["On", "Off"],
+                options: vec![ConfigOption::enabled("On"), ConfigOption::enabled("Off")],
                 skip_write: false,
             },
             ConfigField {
@@ -359,7 +411,7 @@ impl App {
                 lua_key: "__wdeco_traffic_lights__",
                 value: String::new(),
                 default: "On".into(),
-                options: vec!["On", "Off"],
+                options: vec![ConfigOption::enabled("On"), ConfigOption::enabled("Off")],
                 skip_write: false,
             },
             ConfigField {
@@ -368,7 +420,7 @@ impl App {
                 lua_key: "__wdeco_shadow__",
                 value: String::new(),
                 default: "On".into(),
-                options: vec!["On", "Off"],
+                options: vec![ConfigOption::enabled("On"), ConfigOption::enabled("Off")],
                 skip_write: false,
             },
             ConfigField {
@@ -395,7 +447,7 @@ impl App {
                 lua_key: "copy_on_select",
                 value: String::new(),
                 default: "On".into(),
-                options: vec!["On", "Off"],
+                options: vec![ConfigOption::enabled("On"), ConfigOption::enabled("Off")],
                 skip_write: false,
             },
             ConfigField {
@@ -404,7 +456,7 @@ impl App {
                 lua_key: "tab_close_confirmation",
                 value: String::new(),
                 default: "Off".into(),
-                options: vec!["On", "Off"],
+                options: vec![ConfigOption::enabled("On"), ConfigOption::enabled("Off")],
                 skip_write: false,
             },
             ConfigField {
@@ -413,7 +465,7 @@ impl App {
                 lua_key: "pane_close_confirmation",
                 value: String::new(),
                 default: "Off".into(),
-                options: vec!["On", "Off"],
+                options: vec![ConfigOption::enabled("On"), ConfigOption::enabled("Off")],
                 skip_write: false,
             },
             ConfigField {
@@ -422,7 +474,7 @@ impl App {
                 lua_key: "bell_tab_indicator",
                 value: String::new(),
                 default: "On".into(),
-                options: vec!["On", "Off"],
+                options: vec![ConfigOption::enabled("On"), ConfigOption::enabled("Off")],
                 skip_write: false,
             },
             ConfigField {
@@ -431,7 +483,7 @@ impl App {
                 lua_key: "bell_dock_badge",
                 value: String::new(),
                 default: "Off".into(),
-                options: vec!["On", "Off"],
+                options: vec![ConfigOption::enabled("On"), ConfigOption::enabled("Off")],
                 skip_write: false,
             },
             ConfigField {
@@ -440,7 +492,7 @@ impl App {
                 lua_key: "remember_last_cwd",
                 value: String::new(),
                 default: "On".into(),
-                options: vec!["On", "Off"],
+                options: vec![ConfigOption::enabled("On"), ConfigOption::enabled("Off")],
                 skip_write: false,
             },
         ];
@@ -475,6 +527,7 @@ impl App {
 
         let config_path = self.config_path();
         if !config_path.exists() {
+            self.detect_open_target_options();
             return;
         }
 
@@ -505,6 +558,45 @@ impl App {
 
         // Load window_decorations into the Traffic Lights / Shadow pseudo-fields.
         self.load_window_decorations(&content);
+        self.detect_open_target_options();
+    }
+
+    fn detect_open_target_options(&mut self) {
+        let current_open_target = self
+            .fields
+            .iter()
+            .find(|field| field.lua_key == "default_open_target")
+            .map(|field| self.display_value(field).to_string());
+        let detected =
+            crate::open_target::DetectedOpenTargets::detect(current_open_target.as_deref());
+        self.apply_open_target_options(
+            detected
+                .all_options()
+                .iter()
+                .map(|option| ConfigOption {
+                    label: option.label,
+                    enabled: option.enabled,
+                })
+                .collect(),
+        );
+    }
+
+    fn apply_open_target_options(&mut self, options: Vec<ConfigOption>) {
+        if let Some(field) = self
+            .fields
+            .iter_mut()
+            .find(|field| field.lua_key == "default_open_target")
+        {
+            field.options = options;
+            if !field.value.is_empty() && !field.option_enabled(&field.value) {
+                field.skip_write = true;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn apply_open_target_options_for_test(&mut self, options: Vec<ConfigOption>) {
+        self.apply_open_target_options(options);
     }
 
     /// Returns true if a non-commented `config.<key>` assignment exists in content.
@@ -792,7 +884,7 @@ impl App {
     /// format; the caller should set skip_write=true to protect the original line.
     fn normalize_value(lua_key: &str, raw: &str) -> Option<String> {
         match lua_key {
-            "color_scheme" | "font" => {
+            "color_scheme" | "font" | "default_open_target" => {
                 if raw.is_empty()
                     || raw.eq_ignore_ascii_case("nil")
                     || raw.eq_ignore_ascii_case("true")
@@ -945,10 +1037,13 @@ impl App {
                 let current_idx = field
                     .options
                     .iter()
-                    .position(|&o| o == current)
+                    .position(|option| option.label == current)
                     .unwrap_or(0);
                 let next_idx = (current_idx + 1) % 2;
-                let next_value = field.options[next_idx].to_string();
+                if !field.options[next_idx].enabled {
+                    return;
+                }
+                let next_value = field.options[next_idx].label.to_string();
                 self.fields[self.selected].value = next_value;
                 self.fields[self.selected].skip_write = false;
                 self.dirty = true;
@@ -958,7 +1053,8 @@ impl App {
                 self.select_index = field
                     .options
                     .iter()
-                    .position(|&o| o == current)
+                    .position(|option| option.label == current)
+                    .or_else(|| field.options.iter().position(|option| option.enabled))
                     .unwrap_or(0);
             }
         } else {
@@ -980,15 +1076,22 @@ impl App {
     }
 
     fn select_up(&mut self) {
-        if self.select_index > 0 {
-            self.select_index -= 1;
+        let field = &self.fields[self.selected];
+        if let Some(idx) = field.options[..self.select_index]
+            .iter()
+            .rposition(|option| option.enabled)
+        {
+            self.select_index = idx;
         }
     }
 
     fn select_down(&mut self) {
         let field = &self.fields[self.selected];
-        if self.select_index < field.options.len() - 1 {
-            self.select_index += 1;
+        if let Some(idx) = field.options[self.select_index.saturating_add(1)..]
+            .iter()
+            .position(|option| option.enabled)
+        {
+            self.select_index += idx + 1;
         }
     }
 
@@ -1022,14 +1125,19 @@ impl App {
     }
 
     fn confirm_select(&mut self) {
-        let selected_option = self.fields[self.selected].options[self.select_index];
+        let selected_option = &self.fields[self.selected].options[self.select_index];
+        let selected_label = selected_option.label;
         let current_value = self.display_value(&self.fields[self.selected]).to_string();
-        if current_value == selected_option {
+        if current_value == selected_label {
+            self.mode = Mode::Normal;
+            return;
+        }
+        if !selected_option.enabled {
             self.mode = Mode::Normal;
             return;
         }
 
-        self.fields[self.selected].value = selected_option.to_string();
+        self.fields[self.selected].value = selected_label.to_string();
         // Same: explicit user choice overrides the skip_write protection.
         self.fields[self.selected].skip_write = false;
         self.mode = Mode::Normal;
@@ -1336,6 +1444,7 @@ impl App {
                 }
             }
             "font" => format!("wezterm.font('{}')", field.value),
+            "default_open_target" => format!("'{}'", field.value),
             "font_size"
             | "line_height"
             | "window_background_opacity"
@@ -1447,8 +1556,8 @@ fn signal_config_changed() {
 #[cfg(test)]
 mod tests {
     use super::{
-        ensure_editable_config_exists, normal_mode_action, App, Mode, NormalModeAction,
-        KAKU_AUTO_COLOR_SCHEME_EXPR,
+        ensure_editable_config_exists, normal_mode_action, App, ConfigOption, Mode,
+        NormalModeAction, KAKU_AUTO_COLOR_SCHEME_EXPR,
     };
     use crossterm::event::KeyCode;
     use std::path::PathBuf;
@@ -1456,6 +1565,118 @@ mod tests {
 
     fn test_app() -> App {
         App::new(PathBuf::from("/tmp/kaku-config-tui-test.lua"))
+    }
+
+    #[test]
+    fn default_open_target_options_come_from_detection() {
+        let mut app = test_app();
+        app.apply_open_target_options_for_test(vec![
+            ConfigOption::enabled("Auto"),
+            ConfigOption::enabled("Cursor"),
+            ConfigOption::enabled("Finder"),
+        ]);
+
+        let field = app
+            .fields
+            .iter()
+            .find(|field| field.lua_key == "default_open_target")
+            .expect("default_open_target field");
+
+        assert_eq!(
+            field.options.iter().map(|o| o.label).collect::<Vec<_>>(),
+            vec!["Auto", "Cursor", "Finder"]
+        );
+        assert!(field.options.iter().all(|o| o.enabled));
+    }
+
+    #[test]
+    fn missing_current_open_target_is_disabled_and_preserved() {
+        let mut app = test_app();
+        app.apply_open_target_options_for_test(vec![
+            ConfigOption::enabled("Auto"),
+            ConfigOption::enabled("Finder"),
+            ConfigOption::disabled("Cursor"),
+        ]);
+        let idx = app
+            .fields
+            .iter()
+            .position(|field| field.lua_key == "default_open_target")
+            .expect("default_open_target field");
+
+        app.fields[idx].value = "Cursor".to_string();
+        assert_eq!(app.display_value(&app.fields[idx]), "Cursor");
+        assert!(!app.fields[idx].option_enabled("Cursor"));
+    }
+
+    #[test]
+    fn save_config_writes_default_open_target_when_non_default() {
+        let dir = tempdir().expect("tempdir");
+        let config_path = dir.path().join("kaku.lua");
+        std::fs::write(
+            &config_path,
+            "local wezterm = require 'wezterm'\nlocal config = {}\nreturn config\n",
+        )
+        .expect("write config");
+
+        let mut app = App::new(config_path.clone());
+        app.load_config();
+        let idx = app
+            .fields
+            .iter()
+            .position(|field| field.lua_key == "default_open_target")
+            .expect("default_open_target field");
+        app.fields[idx].value = "Finder".to_string();
+        app.fields[idx].skip_write = false;
+
+        app.save_config().expect("save_config");
+
+        let content = std::fs::read_to_string(&config_path).expect("read config");
+        assert!(
+            content.contains("config.default_open_target = 'Finder'"),
+            "expected Finder open target to be written, got:\n{}",
+            content
+        );
+    }
+
+    #[test]
+    fn missing_open_target_is_not_removed_when_unchanged() {
+        let dir = tempdir().expect("tempdir");
+        let config_path = dir.path().join("kaku.lua");
+        let preserved_line =
+            "config.default_open_target    =   \"Cursor\" -- keep disabled current target";
+        let original = format!(
+            "local wezterm = require 'wezterm'\nlocal config = {{}}\n{preserved_line}\nreturn config\n"
+        );
+        std::fs::write(&config_path, &original).expect("write config");
+
+        let mut app = App::new(config_path.clone());
+        app.load_config();
+        app.apply_open_target_options_for_test(vec![
+            ConfigOption::enabled("Auto"),
+            ConfigOption::enabled("Default app"),
+            ConfigOption::enabled("Finder"),
+            ConfigOption::enabled("Terminal"),
+            ConfigOption::disabled("Cursor"),
+        ]);
+        let idx = app
+            .fields
+            .iter()
+            .position(|field| field.lua_key == "default_open_target")
+            .expect("default_open_target field");
+
+        assert_eq!(app.fields[idx].value, "Cursor");
+        assert!(app.fields[idx].skip_write);
+
+        app.save_config().expect("save_config");
+
+        let content = std::fs::read_to_string(&config_path).expect("read config");
+        let expected = format!(
+            "local wezterm = require 'wezterm'\nlocal config = {{}}\n{preserved_line}\nconfig.tab_bar_at_bottom = true\nreturn config\n"
+        );
+        assert_eq!(
+            content, expected,
+            "missing current target config should be preserved exactly"
+        );
     }
 
     #[test]

--- a/kaku/src/config_tui/ui.rs
+++ b/kaku/src/config_tui/ui.rs
@@ -1,5 +1,5 @@
 use ratatui::layout::{Constraint, Layout, Margin, Rect};
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
 
@@ -358,7 +358,7 @@ fn render_selector(frame: &mut ratatui::Frame, area: Rect, app: &App) {
     let longest_option_width = field
         .options
         .iter()
-        .map(|opt| opt.chars().count() as u16)
+        .map(|opt| opt.label.chars().count() as u16)
         .max()
         .unwrap_or(0);
     let popup_width = std::cmp::max(
@@ -399,7 +399,9 @@ fn render_selector(frame: &mut ratatui::Frame, area: Rect, app: &App) {
         .map(|(i, opt)| {
             let is_sel = i == select_index;
             let marker = if is_sel { "› " } else { "  " };
-            let style = if is_sel {
+            let style = if !opt.enabled {
+                Style::default().fg(Color::DarkGray)
+            } else if is_sel {
                 Style::default().fg(primary()).add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(text_fg())
@@ -415,7 +417,7 @@ fn render_selector(frame: &mut ratatui::Frame, area: Rect, app: &App) {
                             Modifier::empty()
                         }),
                 ),
-                Span::styled(*opt, style),
+                Span::styled(opt.label, style),
             ]))
         })
         .collect();

--- a/kaku/src/main.rs
+++ b/kaku/src/main.rs
@@ -33,6 +33,7 @@ mod config_tui;
 mod doctor;
 mod init;
 mod kaku_theme;
+mod open_target;
 mod reset;
 mod shell;
 mod tui_core;

--- a/kaku/src/open_target.rs
+++ b/kaku/src/open_target.rs
@@ -1,0 +1,355 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OpenTargetOption {
+    pub label: &'static str,
+    pub enabled: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct OpenTargetDefinition {
+    pub label: &'static str,
+    pub cli_names: &'static [&'static str],
+    pub app_bundles: &'static [&'static str],
+    pub base: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct DetectedOpenTargets {
+    options: Vec<OpenTargetOption>,
+}
+
+const OPEN_TARGETS: &[OpenTargetDefinition] = &[
+    OpenTargetDefinition {
+        label: "Auto",
+        cli_names: &[],
+        app_bundles: &[],
+        base: true,
+    },
+    OpenTargetDefinition {
+        label: "Default app",
+        cli_names: &[],
+        app_bundles: &[],
+        base: true,
+    },
+    OpenTargetDefinition {
+        label: "Finder",
+        cli_names: &[],
+        app_bundles: &[],
+        base: true,
+    },
+    OpenTargetDefinition {
+        label: "Terminal",
+        cli_names: &[],
+        app_bundles: &[],
+        base: true,
+    },
+    OpenTargetDefinition {
+        label: "VS Code",
+        cli_names: &["code"],
+        app_bundles: &["/Applications/Visual Studio Code.app"],
+        base: false,
+    },
+    OpenTargetDefinition {
+        label: "Cursor",
+        cli_names: &["cursor"],
+        app_bundles: &["/Applications/Cursor.app"],
+        base: false,
+    },
+    OpenTargetDefinition {
+        label: "Windsurf",
+        cli_names: &["windsurf"],
+        app_bundles: &["/Applications/Windsurf.app"],
+        base: false,
+    },
+    OpenTargetDefinition {
+        label: "Kiro",
+        cli_names: &["kiro"],
+        app_bundles: &["/Applications/Kiro.app"],
+        base: false,
+    },
+    OpenTargetDefinition {
+        label: "Antigravity",
+        cli_names: &["antigravity"],
+        app_bundles: &["/Applications/Antigravity.app"],
+        base: false,
+    },
+    OpenTargetDefinition {
+        label: "Zed",
+        cli_names: &["zed"],
+        app_bundles: &["/Applications/Zed.app"],
+        base: false,
+    },
+    OpenTargetDefinition {
+        label: "IntelliJ IDEA",
+        cli_names: &["idea"],
+        app_bundles: &["/Applications/IntelliJ IDEA.app"],
+        base: false,
+    },
+    OpenTargetDefinition {
+        label: "iTerm2",
+        cli_names: &[],
+        app_bundles: &["/Applications/iTerm.app"],
+        base: false,
+    },
+    OpenTargetDefinition {
+        label: "Ghostty",
+        cli_names: &["ghostty"],
+        app_bundles: &["/Applications/Ghostty.app"],
+        base: false,
+    },
+    OpenTargetDefinition {
+        label: "WezTerm",
+        cli_names: &["wezterm"],
+        app_bundles: &["/Applications/WezTerm.app"],
+        base: false,
+    },
+    OpenTargetDefinition {
+        label: "cmux",
+        cli_names: &["cmux"],
+        app_bundles: &["/Applications/cmux.app"],
+        base: false,
+    },
+];
+
+impl DetectedOpenTargets {
+    pub fn detect(current: Option<&str>) -> Self {
+        Self::from_probe_results(probe_cli_names(), probe_app_bundles(), current)
+    }
+
+    pub fn from_probe_results(
+        cli_names: BTreeSet<String>,
+        app_bundles: BTreeSet<String>,
+        current: Option<&str>,
+    ) -> Self {
+        let mut options = Vec::new();
+
+        for definition in OPEN_TARGETS {
+            let detected = definition
+                .cli_names
+                .iter()
+                .any(|name| cli_names.contains(*name))
+                || definition
+                    .app_bundles
+                    .iter()
+                    .any(|bundle| app_bundles.contains(*bundle));
+            let enabled = definition.base || detected;
+            let is_current = current == Some(definition.label);
+
+            if enabled || is_current {
+                options.push(OpenTargetOption {
+                    label: definition.label,
+                    enabled,
+                });
+            }
+        }
+
+        Self { options }
+    }
+
+    pub fn all_options(&self) -> &[OpenTargetOption] {
+        &self.options
+    }
+
+    #[cfg(test)]
+    pub fn selectable_labels(&self) -> Vec<&'static str> {
+        self.options
+            .iter()
+            .filter(|option| option.enabled)
+            .map(|option| option.label)
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub fn option(&self, label: &str) -> Option<&OpenTargetOption> {
+        self.options.iter().find(|option| option.label == label)
+    }
+}
+
+fn probe_cli_names() -> BTreeSet<String> {
+    let path = match std::env::var_os("PATH") {
+        Some(path) => path,
+        None => return BTreeSet::new(),
+    };
+    let mut cli_names = BTreeSet::new();
+
+    for dir in std::env::split_paths(&path) {
+        for definition in OPEN_TARGETS {
+            for name in definition.cli_names {
+                if is_available_cli(&dir.join(name)) {
+                    cli_names.insert((*name).to_string());
+                }
+            }
+        }
+    }
+
+    cli_names
+}
+
+fn probe_app_bundles() -> BTreeSet<String> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let mut app_bundles = BTreeSet::new();
+
+    for definition in OPEN_TARGETS {
+        for bundle in definition.app_bundles {
+            if is_app_bundle(Path::new(bundle))
+                || is_app_bundle(&user_application_bundle(&home, bundle))
+            {
+                app_bundles.insert((*bundle).to_string());
+            }
+        }
+    }
+
+    app_bundles
+}
+
+fn user_application_bundle(home: &Option<PathBuf>, canonical_bundle: &str) -> PathBuf {
+    let bundle_name = Path::new(canonical_bundle)
+        .file_name()
+        .expect("catalog app bundle has a file name");
+
+    home.as_ref()
+        .map(|home| home.join("Applications").join(bundle_name))
+        .unwrap_or_default()
+}
+
+#[cfg(unix)]
+fn is_available_cli(path: &Path) -> bool {
+    path.is_file()
+        && fs::metadata(path)
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_available_cli(path: &Path) -> bool {
+    path.is_file()
+}
+
+fn is_app_bundle(path: &Path) -> bool {
+    path.is_dir()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::fs;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn set(items: &[&str]) -> BTreeSet<String> {
+        items.iter().map(|item| item.to_string()).collect()
+    }
+
+    #[test]
+    fn base_targets_are_always_available() {
+        let detected = DetectedOpenTargets::from_probe_results(set(&[]), set(&[]), None);
+        assert!(detected.selectable_labels().contains(&"Auto"));
+        assert!(detected.selectable_labels().contains(&"Default app"));
+        assert!(detected.selectable_labels().contains(&"Finder"));
+        assert!(detected.selectable_labels().contains(&"Terminal"));
+    }
+
+    #[test]
+    fn unavailable_targets_are_not_displayed_without_current_value() {
+        let detected = DetectedOpenTargets::from_probe_results(set(&[]), set(&[]), None);
+        assert!(!detected
+            .all_options()
+            .iter()
+            .any(|option| option.label == "Cursor"));
+        assert!(!detected
+            .all_options()
+            .iter()
+            .any(|option| option.label == "Ghostty"));
+    }
+
+    #[test]
+    fn detected_cli_targets_are_selectable() {
+        let detected =
+            DetectedOpenTargets::from_probe_results(set(&["cursor", "ghostty"]), set(&[]), None);
+        assert!(detected.option("Cursor").expect("Cursor option").enabled);
+        assert!(detected.option("Ghostty").expect("Ghostty option").enabled);
+    }
+
+    #[test]
+    fn missing_current_value_is_visible_but_disabled() {
+        let detected = DetectedOpenTargets::from_probe_results(set(&[]), set(&[]), Some("Cursor"));
+        let option = detected.option("Cursor").expect("Cursor current option");
+        assert!(!option.enabled);
+        assert_eq!(option.label, "Cursor");
+    }
+
+    #[test]
+    fn app_bundle_detection_enables_targets() {
+        let detected = DetectedOpenTargets::from_probe_results(
+            set(&[]),
+            set(&["/Applications/Antigravity.app"]),
+            None,
+        );
+        assert!(
+            detected
+                .option("Antigravity")
+                .expect("Antigravity option")
+                .enabled
+        );
+    }
+
+    #[test]
+    fn detect_includes_base_targets() {
+        let detected = DetectedOpenTargets::detect(None);
+        assert!(detected.option("Auto").expect("Auto option").enabled);
+        assert!(
+            detected
+                .option("Default app")
+                .expect("Default app option")
+                .enabled
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_executable_path_file_is_not_available_cli() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let path = temp_dir.path().join("cursor");
+        fs::write(&path, "").expect("write cli file");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("set cli permissions");
+
+        assert!(!is_available_cli(&path));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executable_path_file_is_available_cli() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let path = temp_dir.path().join("cursor");
+        fs::write(&path, "").expect("write cli file");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).expect("set cli permissions");
+
+        assert!(is_available_cli(&path));
+    }
+
+    #[test]
+    fn regular_file_named_app_bundle_is_not_detected() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let path = temp_dir.path().join("Cursor.app");
+        fs::write(&path, "").expect("write app file");
+
+        assert!(!is_app_bundle(&path));
+    }
+
+    #[test]
+    fn directory_named_app_bundle_is_detected() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let path = temp_dir.path().join("Cursor.app");
+        fs::create_dir(&path).expect("create app bundle directory");
+
+        assert!(is_app_bundle(&path));
+    }
+}


### PR DESCRIPTION
## Summary

This adds a macOS-only default open target setting for Cmd-clicked file links, so users are no longer forced through the previous VS Code-oriented behavior.

The new setting is exposed through the existing `kaku config` TUI under an Integrations section. Kaku detects available editors and terminal apps when the TUI opens, shows only targets that are actually present, and keeps a previously configured missing target visible as a disabled value so the config state remains understandable.

Supported targets include:

- Auto
- Default app, Finder, Terminal
- VS Code, Cursor, Windsurf, Kiro, Antigravity, Zed, IntelliJ IDEA
- iTerm2, Ghostty, WezTerm, cmux

## Details

- Added a typed `default_open_target` config field with Lua string serialization and parsing.
- Added lightweight macOS target detection for PATH commands, common app bundles, and known bundle-contained CLI paths.
- Moved GUI file-link opening into a dedicated command-building module so behavior is testable without launching apps.
- Preserved the existing path resolution behavior for `file`, `file:line`, and `file:line:col` links.
- Added target-specific command construction:
  - VS Code, Cursor, Windsurf, and Antigravity use goto-style file locations where available.
  - Zed uses suffix-style file locations.
  - IntelliJ IDEA uses `--line` and `--column` flags.
  - Terminal-style targets open the containing directory for file links and the directory itself for directory links.
  - Finder reveals files and opens directories.
  - Default app uses the macOS default handler.
- Added Auto fallback ordering that tries `$VISUAL` / `$EDITOR` from the GUI process environment first, then detected IDE targets, then macOS default app, then Finder.
- Kept opening failures silent in the UI, with fallback continuing through the remaining candidates.

## Test Plan

- `cargo test -p config default_open_target`
- `cargo test -p kaku open_target`
- `cargo test -p kaku-gui open_target`
- `cargo fmt --all -- --check`
- `git diff --cached --check`

Manual checks covered selecting detected targets in the config TUI and Cmd-clicking file links with line/column suffixes for editor targets and directory-opening behavior for terminal targets.
