### PR TITLE
chore: gitignore .gitnexus index dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ AGENT.md
 AGENTS.md
 CLAUDE.md
 .agents/
+.gitnexus


### PR DESCRIPTION
Why: gitnexus indexer drops state into .gitnexus/ at repo root; not source.