### PR TITLE
fix(macos): layout-safe Cmd+letter for non-QWERTY keyboards

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -3067,6 +3067,11 @@ fn is_ascii_punctuation_text(s: &str) -> bool {
     matches!((chars.next(), chars.next()), (Some(c), None) if c.is_ascii_punctuation())
 }
 
+fn is_ascii_letter_text(s: &str) -> bool {
+    let mut chars = s.chars();
+    matches!((chars.next(), chars.next()), (Some(c), None) if c.is_ascii_alphabetic())
+}
+
 fn is_command_alnum_shortcut(unmod: &str, modifiers: Modifiers, virtual_key: u16) -> bool {
     // Require Cmd (SUPER), disallow Alt/Ctrl (Shift is permitted).
     // Prevents Cmd+alnum shortcuts from failing when a non-Latin IME is active,
@@ -3275,6 +3280,26 @@ mod tests {
             Modifiers::SUPER,
             kVK_ANSI_M
         ));
+    }
+
+    #[test]
+    fn command_alnum_shortcut_still_matches_letter_on_remapped_vkey() {
+        // AZERTY "a" sits on kVK_ANSI_Q; must still intercept so NSMenu's
+        // non-Latin-IME mismatch path cannot run.
+        assert!(is_command_alnum_shortcut("a", Modifiers::SUPER, kVK_ANSI_Q));
+        assert!(is_command_alnum_shortcut("z", Modifiers::SUPER, kVK_ANSI_W));
+    }
+
+    #[test]
+    fn ascii_letter_text_matches_only_single_latin_letters() {
+        assert!(is_ascii_letter_text("a"));
+        assert!(is_ascii_letter_text("Z"));
+        assert!(!is_ascii_letter_text(""));
+        assert!(!is_ascii_letter_text("ab"));
+        assert!(!is_ascii_letter_text(","));
+        assert!(!is_ascii_letter_text("1"));
+        assert!(!is_ascii_letter_text("\u{3148}"));
+        assert!(!is_ascii_letter_text("\u{00e9}"));
     }
 
     #[test]
@@ -4319,7 +4344,10 @@ impl WindowView {
                 // Use exact match to avoid affecting Cmd+Ctrl+Shift+symbol etc.
                 (true, unmod)
             } else if is_command_alnum_shortcut(unmod, modifiers, virtual_key) {
-                (true, unmod)
+                // Latin layouts: trust the labeled letter (AZERTY "a" sits on
+                // kVK_ANSI_Q, so the physical key would mis-fire Cmd+Q). Empty
+                // or non-ASCII unmod (true non-Latin IME) keeps the vkey path.
+                (!is_ascii_letter_text(unmod), unmod)
             } else {
                 (false, unmod)
             };


### PR DESCRIPTION
Hi! First open-source PR for me, so apologies in advance if I'm missing something.

I'm on a French AZERTY keyboard and noticed Cmd+A would close Kaku entirely, no crash report, just a clean exit. Pretty sure this is what's been hitting #220 too, the quit-origin log you added (`WindowScopeQuitApplication`) is what made the diagnosis possible, so thanks for that.

Cause: on AZERTY the labeled "A" sits on the physical Q position (vkey 12). The Cmd+alnum branch in `key_common` (`window/src/os/macos/window.rs`) forces `prefer_vkey=true` for any alnum vkey, so the event ends up as Cmd+Q downstream, and Cmd+Q is the default QuitApplication binding. Same story for Cmd+Z (CloseCurrentTab) and Cmd+Shift+A (your AI Config shortcut becomes unreachable).

Same shape as the bug you fixed in e485b8a for Cmd+, on AZERTY (punctuation on an alnum vkey), just for letters this time. Added a `is_ascii_letter_text` helper next to your `is_ascii_punctuation_text`, and in `key_common` the Cmd+alnum branch now downgrades `prefer_vkey` to false when `unmod` is a single ASCII letter,  that covers QWERTY / AZERTY / Dvorak / Colemak / Bépo. Empty or non-ASCII `unmod` (real non-Latin IME) keeps the physical-key fallback, so the #147 fix stays intact.

Tested locally on macOS 26.3.1 / Apple Silicon / French AZERTY:

Before: `Cmd+A` → `KeyEvent { key: Char('q'), ... }` → `quit requested origin=WindowScopeQuitApplication`
After: `Cmd+A` → `KeyEvent { key: Char('a'), ... }` → falls through to the shell-side select-all sequence as expected

I deliberately did not add a Cmd+A binding at the app level, saw your call on #261/#262, this PR just stops the existing Cmd+Q default from firing on the wrong key. Cmd+Q on AZERTY (label Q sits on physical A) still quits, as users expect.

Refs #220, #147, #305.
