### PR TITLE
[codex] Fix AI SSE parsing and custom headers

### DIFF
--- a/kaku-gui/src/ai_client.rs
+++ b/kaku-gui/src/ai_client.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 
 use crate::ai_auth;
-use reqwest::header::{HeaderName, HeaderValue};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
 const DEFAULT_MODEL: &str = "gpt-5.4-mini";
 const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
@@ -476,16 +476,17 @@ impl AiClient {
 
     fn apply_custom_headers(
         &self,
-        mut req: reqwest::blocking::RequestBuilder,
+        req: reqwest::blocking::RequestBuilder,
     ) -> Result<reqwest::blocking::RequestBuilder> {
+        let mut headers = HeaderMap::new();
         for (name, value) in &self.config.custom_headers {
             let header_name = HeaderName::from_bytes(name.as_bytes())
                 .with_context(|| format!("invalid custom header name `{name}`"))?;
             let header_value = HeaderValue::from_str(value)
                 .with_context(|| format!("invalid custom header value for `{name}`"))?;
-            req = req.header(header_name, header_value);
+            headers.insert(header_name, header_value);
         }
-        Ok(req)
+        Ok(req.headers(headers))
     }
 
     /// Single chat step with optional tool support.
@@ -539,7 +540,7 @@ impl AiClient {
                 break;
             }
             let line = line.context("read SSE line")?;
-            let Some(data) = line.strip_prefix("data: ") else {
+            let Some(data) = sse_data_payload(&line) else {
                 continue;
             };
             if data.trim() == "[DONE]" {
@@ -716,6 +717,10 @@ fn reasoning_delta_text<'a>(
         .or_else(|| choice["reasoning"].as_str())
 }
 
+fn sse_data_payload(line: &str) -> Option<&str> {
+    line.strip_prefix("data:").map(str::trim_start)
+}
+
 // ─── Inline <think> / <thinking> tag filter ─────────────────────────────────
 
 const THINK_TAG_PAIRS: &[(&str, &str)] = &[("<think>", "</think>"), ("<thinking>", "</thinking>")];
@@ -841,7 +846,8 @@ fn detect_provider_with_auth(base_url: &str, auth_type: &str) -> &'static str {
 mod tests {
     use super::{
         detect_provider_with_auth, parse_custom_headers, reasoning_delta_text,
-        should_roundtrip_reasoning_content, ApiMessage, InlineThinkFilter, ThinkSegment,
+        should_roundtrip_reasoning_content, sse_data_payload, ApiMessage, InlineThinkFilter,
+        ThinkSegment,
     };
 
     #[test]
@@ -921,6 +927,13 @@ mod tests {
 
         let choice = serde_json::json!({"delta": {"content": "visible"}});
         assert_eq!(reasoning_delta_text(&choice, &choice["delta"]), None);
+    }
+
+    #[test]
+    fn sse_data_payload_accepts_optional_space_after_colon() {
+        assert_eq!(sse_data_payload("data:{\"x\":1}"), Some("{\"x\":1}"));
+        assert_eq!(sse_data_payload("data: {\"x\":1}"), Some("{\"x\":1}"));
+        assert_eq!(sse_data_payload("event: message"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 摘要

Fix AI chat compatibility with stricter OpenAI-compatible providers, originally observed while testing Kimi Coding. Kimi requires the request `User-Agent` to meet its client requirements, and Kaku's previous header handling made that difficult to configure through `custom_headers`.

This PR keeps the fix generic: it does not add any provider-specific hardcoded behavior. Instead, it makes custom headers replace existing request headers and relaxes SSE parsing to support both `data:{...}` and `data: {...}` event formats.

修复 AI Chat 对请求要求更严格的 OpenAI-compatible 服务的兼容性。这个问题最初是在适配 Kimi Coding 时发现的：Kimi 对请求 `User-Agent` 有明确要求，而 Kaku 之前的 header 处理方式让用户很难通过 `custom_headers` 正确配置。

这个 PR 保持通用实现：不加入任何服务商专用的硬编码逻辑，而是让自定义 header 能覆盖已有请求头，并让 SSE 解析同时支持 `data:{...}` 和 `data: {...}` 两种事件格式。

## Root Cause / 根因

Kaku previously applied `custom_headers` with `RequestBuilder::header()`. For some headers, this can result in duplicate values instead of reliably replacing the existing request header. Providers with strict request-header validation may then read the wrong value and reject the request.

之前 Kaku 使用 `RequestBuilder::header()` 应用 `custom_headers`。对部分 header 来说，这可能会产生重复值，而不是稳定覆盖已有请求头。对于严格校验请求头的服务商，服务端可能读取到错误的值并拒绝请求。

Separately, Kaku parsed SSE chunks only when a line started with `data: `. Some compatible providers emit valid SSE lines as `data:{...}` without a space after the colon, so Kaku ignored those chunks and the chat could finish with no visible output.

另外，Kaku 之前只解析以 `data: ` 开头的 SSE 行。部分兼容服务会返回合法的 `data:{...}` 格式，冒号后没有空格，导致 Kaku 跳过这些 chunk，最终表现为请求结束但没有可见回复。

## Changes / 改动

- Apply `custom_headers` through a `HeaderMap`, allowing same-name headers such as `User-Agent` to replace existing values.
- Parse SSE `data:` lines with or without a space after the colon.
- Add a unit test for both `data:{...}` and `data: {...}` formats.

- 通过 `HeaderMap` 应用 `custom_headers`，允许 `User-Agent` 等同名 header 覆盖已有值。
- 兼容解析冒号后有空格和无空格的 SSE `data:` 行。
- 增加单元测试，覆盖 `data:{...}` 和 `data: {...}` 两种格式。

## Validation / 验证

```bash
cargo test -p kaku-gui sse_data_payload_accepts_optional_space_after_colon --lib
cargo build --release -p kaku-gui
```

Manual smoke test with a Kimi-compatible custom endpoint:

```bash
k --new hello
```

手动使用 Kimi-compatible 自定义 endpoint 验证，`k --new hello` 可以正常返回 AI 回复，不再空白。
