### PR TITLE
fix(macos): route keystrokes to IME during active composition

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -4466,17 +4466,21 @@ impl WindowView {
         let only_left_alt = (modifiers & alt_mods) == (Modifiers::LEFT_ALT | Modifiers::ALT);
         let only_right_alt = (modifiers & alt_mods) == (Modifiers::RIGHT_ALT | Modifiers::ALT);
 
+        let has_active_ime_composition = Self::get_this(this)
+            .map(|s| !s.inner.borrow().ime_text.is_empty())
+            .unwrap_or(false);
+
         // Also respect `send_composed_key_when_(left|right)_alt_is_pressed` configs
         // when `use_ime` is true.
-        let forward_to_ime = {
-            if only_left_alt && !send_composed_key_when_left_alt_is_pressed {
-                false
-            } else if only_right_alt && !send_composed_key_when_right_alt_is_pressed {
-                false
-            } else {
-                modifiers.is_empty()
-                    || modifiers.intersects(config_handle.macos_forward_to_ime_modifier_mask)
-            }
+        let forward_to_ime = if has_active_ime_composition {
+            true
+        } else if only_left_alt && !send_composed_key_when_left_alt_is_pressed {
+            false
+        } else if only_right_alt && !send_composed_key_when_right_alt_is_pressed {
+            false
+        } else {
+            modifiers.is_empty()
+                || modifiers.intersects(config_handle.macos_forward_to_ime_modifier_mask)
         };
 
         if key_is_down && use_ime && forward_to_ime {


### PR DESCRIPTION
Hi! For #373, originally reported by @kosuketut. I could reproduce it consistently with a French AZERTY layout + Japanese-Romaji IME, so it's not Hangul-specific.

When the IME has marked (pre-edit) text active, `Ctrl+H` falls through the `forward_to_ime` decision in `key_common`: CTRL is not in `macos_forward_to_ime_modifier_mask` (default = `SHIFT`), so the event bypasses `interpretKeyEvents` entirely. `key_common` then produces a `KeyEvent { key: Char('h'), modifiers: CTRL }` → translated to BS and sent straight to the terminal. The user sees a character disappear from the already-committed text while their composition stays intact.

The fix: read `inner.ime_text` at the top of the decision and force `forward_to_ime = true` while it's non-empty. The IME then receives the keystroke and edits its pre-edit via `setMarkedText:` as expected. When no composition is active, the previous behavior is unchanged.

Trace from a debug build on macOS 26.3.1 / Apple Silicon / French AZERTY + Japanese-Romaji, after typing `echo "hello world"` then composing `nihongo` and pressing Ctrl+H:

Before:
```
perform_key_equivalent: chars=`\u{8}` unmod=`h` modifiers=`CTRL` virtual_key=4
key_common KeyEvent { key: Char('h'), modifiers: CTRL, ... }   ← went to terminal
↳ the trailing `"` of `hello world"` got eaten
```

After:
```
perform_key_equivalent: chars=`\u{8}` unmod=`h` modifiers=`CTRL` virtual_key=4
set_marked_text_selected_range_replacement_range にほん   ← IME shrunk pre-edit IME state: Acted, last_event: None
↳ `hello world"` untouched; composition went にほんご → にほん → にほ → に on three Ctrl+H
```

Closes #373.
