### PR TITLE
fix(render): toast text clipped on low-DPI displays

### DIFF
--- a/kaku-gui/src/termwindow/render/paint.rs
+++ b/kaku-gui/src/termwindow/render/paint.rs
@@ -744,8 +744,19 @@ impl crate::TermWindow {
 
         let dimensions = self.dimensions;
         let border = self.get_os_border();
-        // Calculate width based on message length (each char ~cell_width + padding)
-        let approx_width = (message.len() as f32 + 1.5) * metrics.cell_size.width as f32;
+        let shape_window = self.window.as_ref().unwrap().clone();
+        let shaped = font.shape(
+            &message,
+            move || shape_window.notify(TermWindowNotif::InvalidateShapeCache),
+            |_| {},
+            None,
+            wezterm_bidi::Direction::LeftToRight,
+            None,
+            None,
+        )?;
+        let text_pixel_width: f32 = shaped.iter().map(|g| g.x_advance.get() as f32).sum();
+        // 1.5 cells matches the Cells(0.75) horizontal padding; ceil + 1 px guards against rounding.
+        let approx_width = (text_pixel_width + 1.5 * metrics.cell_size.width as f32).ceil() + 1.0;
         let toast_height = metrics.cell_size.height as f32 * 1.5;
         // Use consistent margin based on cell size
         let h_margin = metrics.cell_size.width as f32 * 2.0;


### PR DESCRIPTION
Hi! For #379, reported by @trongthanh. Reproduced on a non-retina external display: select text → toast renders as `Copie` instead of `Copied`.

The toast box in `paint_toast` (`kaku-gui/src/termwindow/render/paint.rs`) was sized from a width approximation:

```rust
let approx_width = (message.len() as f32 + 1.5) * metrics.cell_size.width as f32;
```

The title font is proportional, so `message.len() * cell_width` is just an upper-bound estimate. `compute_element` clips the trailing glyph when its right edge `>= max_x`, and `Dimension::Cells.evaluate_as_pixels` floors when converting padding to pixels. On retina the rounding stays sub-pixel and the last char fits; on a 1× display the floor eats enough slack that `x_pos + glyph_width == max_x` and the trailing glyph is dropped.

Shape the message up front, sum the actual `x_advance` values, and keep the same 1.5 cells of padding plus a 1 px / `ceil()` margin to absorb any remaining downstream rounding:

```rust
let shaped = font.shape(&message, …)?;
let text_pixel_width: f32 = shaped.iter().map(|g| g.x_advance.get() as f32).sum();
let approx_width = (text_pixel_width + 1.5 * metrics.cell_size.width as f32).ceil() + 1.0;
```

Tested on macOS 26.3.1 / Apple Silicon, internal retina panel and non-retina external display.

Before (non-retina): toast shows `Copie`.
After (non-retina): toast shows `Copied`.
Retina behavior unchanged.

The other toasts (`Auto copy disabled…`, AI progress/result notices) go through the same code path, so they all stop relying on the proportional-cell-width approximation.

Closes #379.
