### PR TITLE
feat: add Smart Tab mode configuration to `kaku config` TUI

### DIFF
--- a/assets/macos/Kaku.app/Contents/Resources/kaku.lua
+++ b/assets/macos/Kaku.app/Contents/Resources/kaku.lua
@@ -4020,6 +4020,16 @@ config.color_scheme = resolve_kaku_color_scheme(config.color_scheme)
 config.set_environment_variables = config.set_environment_variables or {}
 config.set_environment_variables['COLORFGBG'] = (config.color_scheme == 'Kaku Light') and '0;15' or '15;0'
 
+-- Smart Tab mode: "completion_first" (default), "suggestion_first", or "off"
+-- Bridges kaku.lua config to the shell env vars read by setup_zsh.sh.
+-- Env vars set in the user's shell rc still take precedence.
+local smart_tab = config.smart_tab_mode or 'completion_first'
+if smart_tab == 'off' then
+  config.set_environment_variables['KAKU_SMART_TAB_DISABLE'] = '1'
+elseif smart_tab == 'suggestion_first' then
+  config.set_environment_variables['KAKU_TAB_ACCEPT_SUGGEST_FIRST'] = '1'
+end
+
 -- ===== Window Frame (theme-aware) =====
 get_window_frame_colors = function(scheme)
   scheme = resolve_kaku_color_scheme(scheme)

--- a/docs/features.md
+++ b/docs/features.md
@@ -157,14 +157,34 @@ Run `kaku init` to provision `~/.config/kaku/fish/kaku.fish` for fish users. `ka
 - **Lazygit**: Terminal git UI.
 - **Yazi**: Terminal file manager.
 
-**Disabling Smart Tab**
+**Smart Tab**
 
-If you use your own completion workflow like `fzf-tab`, add this before sourcing the Kaku shell integration:
+Kaku's Smart Tab overrides the Tab key in zsh to provide smarter completion behavior. It supports three modes:
+
+| Mode | Behavior | Environment Variable |
+| :--- | :--- | :--- |
+| Completion First (default) | Tab shows the completion list; use `→` to accept autosuggestions | — |
+| Suggestion First | Tab accepts autosuggestions when available, falls back to completion | `KAKU_TAB_ACCEPT_SUGGEST_FIRST=1` |
+| Off | Disables Smart Tab entirely, restoring native zsh Tab behavior | `KAKU_SMART_TAB_DISABLE=1` |
+
+You can also set the mode via `kaku config` (the **Smart Tab** option under Behavior) or in `kaku.lua`:
+
+```lua
+config.smart_tab_mode = "completion_first"   -- default
+config.smart_tab_mode = "suggestion_first"   -- Tab accepts autosuggestions first
+config.smart_tab_mode = "off"                -- disable Smart Tab
+```
+
+If you prefer environment variables (e.g. because you share your zshrc across terminals), add one of these before sourcing the Kaku shell integration:
 
 ```zsh
-export KAKU_SMART_TAB_DISABLE=1
+export KAKU_TAB_ACCEPT_SUGGEST_FIRST=1  # suggestion-first mode
+# or
+export KAKU_SMART_TAB_DISABLE=1         # disable Smart Tab
 ```
 
 ```fish
 set -gx KAKU_SMART_TAB_DISABLE 1
 ```
+
+> **Note:** Environment variables set in your shell rc take precedence over `kaku.lua` settings. Smart Tab is only active inside Kaku sessions (`TERM_PROGRAM=Kaku`).

--- a/kaku/src/config_tui/mod.rs
+++ b/kaku/src/config_tui/mod.rs
@@ -453,6 +453,15 @@ impl App {
                 options: vec!["On", "Off"],
                 skip_write: false,
             },
+            ConfigField {
+                section: "Behavior",
+                key: "Smart Tab",
+                lua_key: "smart_tab_mode",
+                value: String::new(),
+                default: "Completion First".into(),
+                options: vec!["Completion First", "Suggestion First", "Off"],
+                skip_write: false,
+            },
         ];
 
         Self {
@@ -869,6 +878,15 @@ impl App {
                     Some("On".into())
                 } else {
                     None
+                }
+            }
+            "smart_tab_mode" => {
+                let value = raw.trim().trim_matches('\'').trim_matches('"');
+                match value {
+                    "completion_first" => Some("Completion First".into()),
+                    "suggestion_first" => Some("Suggestion First".into()),
+                    "off" => Some("Off".into()),
+                    _ => None,
                 }
             }
             "macos_global_hotkey" => {
@@ -1437,6 +1455,18 @@ impl App {
                     "{}".into()
                 } else {
                     "{ 'calt=0', 'clig=0', 'liga=0' }".into()
+                }
+            }
+            "smart_tab_mode" => {
+                let effective = if field.value.is_empty() {
+                    &field.default
+                } else {
+                    &field.value
+                };
+                match effective.as_str() {
+                    "Suggestion First" => "'suggestion_first'".into(),
+                    "Off" => "'off'".into(),
+                    _ => "'completion_first'".into(),
                 }
             }
             "macos_global_hotkey" => {

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -178,11 +178,14 @@ config_tui:
   bell_tab_prefix: "标签响铃标记"
   bell_dock_badge: "Dock 响铃徽标"
   remember_last_directory: "记住上次目录"
+  smart_tab: "Smart Tab 模式"
 
   # ─ 枚举值 (options / defaults) ─
   on: "开"
   off: "关"
   auto: "自动"
+  completion_first: "补全优先"
+  suggestion_first: "建议优先"
   kaku_dark: "Kaku 深色"
   kaku_light: "Kaku 浅色"
   bottom: "下方"


### PR DESCRIPTION
## Summary

This PR makes Smart Tab behavior fully configurable from the `kaku config` TUI, and improves documentation to cover all three Smart Tab modes.

## Motivation

Kaku's Smart Tab supports three modes, but currently:
- Only `KAKU_SMART_TAB_DISABLE` is documented; `KAKU_TAB_ACCEPT_SUGGEST_FIRST` is undocumented
- Both options require manually editing shell environment variables, which is inconvenient for many users
- There is no way to configure Smart Tab from the `kaku config` TUI

This change addresses all three issues.

## Changes

### 1. `kaku config` TUI — new Smart Tab option (`kaku/src/config_tui/mod.rs`)

Adds a **Smart Tab** field to the Behavior section with three options:

| Option | Behavior |
| :--- | :--- |
| Completion First (default) | Tab shows the completion list; use `→` to accept autosuggestions |
| Suggestion First | Tab accepts autosuggestions when available, falls back to completion |
| Off | Disables Smart Tab entirely, restoring native zsh Tab behavior |

The value is persisted as `config.smart_tab_mode` in `kaku.lua`.

### 2. Lua → shell env var bridge (`assets/macos/Kaku.app/Contents/Resources/kaku.lua`)

Bridges the `config.smart_tab_mode` setting to the shell environment variables (`KAKU_SMART_TAB_DISABLE` / `KAKU_TAB_ACCEPT_SUGGEST_FIRST`) using the existing `config.set_environment_variables` mechanism — the same pattern already used for `COLORFGBG`.

Environment variables set manually in the user's shell rc still take precedence, preserving backward compatibility.

### 3. Documentation (`docs/features.md`)

Expands the existing "Disabling Smart Tab" section into a complete **Smart Tab** configuration guide covering:
- All three modes with a comparison table
- `kaku.lua` configuration examples
- Environment variable fallback for users sharing zshrc across terminals
- Precedence rules

### 4. i18n (`locales/zh-CN.yml`)

Adds Chinese translations for the new config field and option values:
- `smart_tab` → "Smart Tab 模式"
- `completion_first` → "补全优先"
- `suggestion_first` → "建议优先"

## Files Changed

- `kaku/src/config_tui/mod.rs` — Add ConfigField + normalize/serialize logic
- `assets/macos/Kaku.app/Contents/Resources/kaku.lua` — Env var bridge
- `docs/features.md` — Expanded Smart Tab documentation
- `locales/zh-CN.yml` — Chinese translations

## Testing

- The new config field follows the same patterns as existing On/Off/selector fields in the TUI
- The Lua bridge follows the proven `COLORFGBG` pattern at the same code location
- No changes to `setup_zsh.sh` — existing env var handling is reused as-is