### PR TITLE
fix(tab-bar): non-fancy mode top inset and cell height

### DIFF
--- a/kaku-gui/src/termwindow/render/tab_bar.rs
+++ b/kaku-gui/src/termwindow/render/tab_bar.rs
@@ -65,11 +65,14 @@ impl crate::TermWindow {
 
         let palette = self.palette().clone();
 
-        // Register the tab bar location
+        // Natural metrics keep the single-line bar from inheriting the
+        // terminal's line_height padding.
+        let tab_metrics = RenderMetrics::with_font_metrics(&self.fonts.default_font()?.metrics());
+
         self.ui_items.append(&mut self.tab_bar.compute_ui_items(
             tab_bar_y as usize,
-            self.render_metrics.cell_size.height as usize,
-            self.render_metrics.cell_size.width as usize,
+            tab_metrics.cell_size.height as usize,
+            tab_metrics.cell_size.width as usize,
         ));
 
         let window_is_transparent =
@@ -125,14 +128,13 @@ impl crate::TermWindow {
                 cursor: &Default::default(),
                 palette: &palette,
                 dims: &RenderableDimensions {
-                    cols: self.dimensions.pixel_width
-                        / self.render_metrics.cell_size.width as usize,
+                    cols: self.dimensions.pixel_width / tab_metrics.cell_size.width as usize,
                     physical_top: 0,
                     scrollback_rows: 0,
                     scrollback_top: 0,
                     viewport_rows: 1,
                     dpi: self.terminal_size.dpi,
-                    pixel_height: self.render_metrics.cell_size.height as usize,
+                    pixel_height: tab_metrics.cell_size.height as usize,
                     pixel_width: self.terminal_size.pixel_width,
                     reverse_video: false,
                 },
@@ -153,7 +155,7 @@ impl crate::TermWindow {
                 style: None,
                 font: None,
                 use_pixel_positioning: self.config.experimental_pixel_positioning,
-                render_metrics: self.render_metrics,
+                render_metrics: tab_metrics,
                 shape_key: None,
                 password_input: false,
             },
@@ -172,7 +174,7 @@ impl crate::TermWindow {
             let font = fontconfig.title_font()?;
             Ok((font.metrics().cell_height.get() as f32 * 1.75).ceil())
         } else {
-            Ok(render_metrics.cell_size.height as f32)
+            Ok(render_metrics.natural_cell_height as f32)
         }
     }
 
@@ -191,7 +193,7 @@ impl crate::TermWindow {
             // height. The two differ by ~1-2 pixels in typical configs.
             (render_metrics.cell_size.height as f32 * 1.75).ceil()
         } else {
-            render_metrics.cell_size.height as f32
+            render_metrics.natural_cell_height as f32
         }
     }
 

--- a/kaku-gui/src/termwindow/render/tab_bar.rs
+++ b/kaku-gui/src/termwindow/render/tab_bar.rs
@@ -8,17 +8,15 @@ use window::color::LinearRgba;
 
 impl crate::TermWindow {
     pub fn paint_tab_bar(&mut self, layers: &mut TripleLayerQuadAllocator) -> anyhow::Result<()> {
-        let _border = self.get_os_border();
+        let border = self.get_os_border();
         let tab_bar_height = self.tab_bar_pixel_height()?;
         let tab_bar_y = if self.config.tab_bar_at_bottom {
-            // Position tab bar at the very bottom for a "flush" appearance.
-            // The tab bar renders its own background, covering the bottom area.
-            ((self.dimensions.pixel_height as f32) - tab_bar_height).max(0.)
+            ((self.dimensions.pixel_height as f32) - tab_bar_height - border.bottom.get() as f32)
+                .max(0.)
         } else {
-            // Position tab bar at the very top (y=0) for a "flush" appearance.
-            // The fancy tab bar renders its own background, so it will cover
-            // the titlebar area completely.
-            0.0
+            // Offset below the OS top inset so cells aren't clipped by the
+            // macOS rounded corner / integrated buttons window mask.
+            border.top.get() as f32
         };
         let panes = self.get_panes_to_render();
         let force_opaque_tab_bar_background = forces_opaque_kaku_tui_window_background(&panes);


### PR DESCRIPTION
Hi! Two non-fancy tab-bar bugs in `paint_tab_bar` (`kaku-gui/src/termwindow/render/tab_bar.rs`).

**#387** (reported by @dsaad68): with top tab bar + `INTEGRATED_BUTTONS|RESIZE`, tab cells get clipped at the top by the macOS rounded corner and traffic-light area. `tab_bar_y` was hardcoded to `0.0`, ignoring the 16 px inset that `get_os_border()` folds into `border.top`. The fancy path and the hover detection in `mod.rs:3344` already apply it. Non-fancy just dropped it. Fix: apply `border.top.get()` (and `border.bottom.get()` for bottom bars).

**#382** (reported by @reiy-leo): double-click rename, text comes back oversized and clipped above and below the cell. The rename modal sizes from `anchor.height`, which came from `render_metrics.cell_size.height` (terminal cell scaled by `config.line_height`). With `line_height > 1` the modal's title-font line plus padding overflows the inflated cell. Fix: use `natural_cell_height` for the non-fancy bar, like the fancy path already does for the title font.

**Natural vs scaled** (@tw93 call I'd like you to make): I picked natural because it mirrors the fancy path and drops the silent dependency on `line_height` for a single-line element. Visible cost: the bar gets a touch shorter when `line_height > 1`. If you'd rather keep the current breathing room, the alternative is to clamp the rename modal's padding so it fits in `anchor.height` regardless. Same end result for #382, different feel for the bar.

Tested on macOS 26.3.1 / Apple Silicon / Monolisa 17pt / `line_height = 1.28` / top tab bar with integrated buttons.

Before: cells clipped at top, rename modal text spills above and below the cell.
After: cells fully visible, traffic-light row sits cleanly above the tabs, rename modal lays out inside the cell.

Closes #387, Closes #382.
