### PR TITLE
fix(macos): exit fullscreen Space when red dot hides the window

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1286,7 +1286,19 @@ impl WindowOps for Window {
 
     fn order_out(&self) {
         Connection::with_window_inner(self.id, |inner| {
-            inner.order_out();
+            // orderOut on a native-fullscreen window leaves the Space behind
+            // as a stranded black overlay. Exit the Space first; the hide is
+            // completed from did_exit_fullscreen once AppKit tears it down.
+            if inner.is_native_fullscreen() {
+                if let Some(window_view) =
+                    unsafe { WindowView::get_this(&**inner.view) }
+                {
+                    window_view.order_out_on_fullscreen_exit.set(true);
+                }
+                inner.exit_native_fullscreen();
+            } else {
+                inner.order_out();
+            }
             Ok(())
         });
     }
@@ -2913,6 +2925,9 @@ struct WindowView {
     /// Set when window_will_close fires; prevents fullscreen transition
     /// handlers from dispatching events to an already-destroyed window.
     is_closing: Cell<bool>,
+    /// Queued by order_out for a native-fullscreen window; consumed by
+    /// did_exit_fullscreen to finish hiding once the Space exits.
+    order_out_on_fullscreen_exit: Cell<bool>,
 }
 
 fn arm_display_change_opengl_present_defer(
@@ -4956,6 +4971,19 @@ impl WindowView {
                     events.dispatch(WindowEvent::NeedRepaint);
                 }
             }
+
+            if this.order_out_on_fullscreen_exit.replace(false) {
+                if let Ok(inner) = this.inner.try_borrow() {
+                    if let Some(window) = inner.window.as_ref() {
+                        let window = window.load();
+                        if !window.is_null() {
+                            unsafe {
+                                let () = msg_send![*window, orderOut: nil];
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -5454,6 +5482,7 @@ impl WindowView {
             native_fullscreen_transition_start: Cell::new(None),
             resize_retry_scheduled: Cell::new(false),
             is_closing: Cell::new(false),
+            order_out_on_fullscreen_exit: Cell::new(false),
         }));
 
         unsafe {


### PR DESCRIPTION
Hi! For #388, originally reported by @Xiangyinfly and with a key follow-up from @soy-sauce-rice: in 0.11.0 Cmd+W in native fullscreen got cleaned up, but the red close button still leaves a black fullscreen Space behind.

Cause: the two close paths don't go through the same code in `window/src/os/macos/window.rs`.

- Cmd+W on the last pane goes through `close_current_pane` → `close_current_tab` → `mux.remove_tab`, which cascades to window destruction and ends in `[NSWindow close]`. AppKit handles the fullscreen exit transition as part of close, so the Space tears down cleanly. That's the "fixes Cmd+W in fullscreen with one tab" comment at `kaku-gui/src/termwindow/mod.rs:5186`.
- The red dot fires `windowShouldClose:` → `WindowEvent::CloseRequested` → `close_requested` (`kaku-gui/src/termwindow/mod.rs:1119`), which on macOS calls `_window.order_out()` to preserve tabs/panes/processes. `WindowOps::order_out` then sends `[NSWindow orderOut:]` to the NSWindow. On a window that owns a native-fullscreen Space, orderOut hides the window but leaves the Space alive as an empty black overlay. The user is stuck until Cmd+Q.

Fix lives entirely in `window/src/os/macos/window.rs`:

- The trait-level `WindowOps::order_out` now checks `inner.is_native_fullscreen()`. If true, it sets a new `order_out_on_fullscreen_exit: Cell<bool>` flag on the `WindowView` and calls `inner.exit_native_fullscreen()` — that runs `[NSWindow toggleFullScreen:]`, which starts the standard AppKit exit transition.
- The existing `did_exit_fullscreen` delegate fires when the transition lands and the Space is gone. It now consumes the flag and sends the deferred `orderOut:` to the NSWindow at that point, with the same `!window.is_null()` guard used by `persist_window_state_after_move` and friends in this file.
- Non-fullscreen path is untouched (still a plain `inner.order_out()`).
- Global hotkey hide-while-fullscreen path is also untouched: it calls `inner.order_out()` directly from `window/src/os/macos/app.rs:481` and bypasses the trait impl, so windows still hide-in-place when toggled by the hotkey and restore on the next press.

`toggleFullScreen:` doesn't expose a completion handler, so the Cell<bool> + delegate hook is the natural shape — same pattern as `is_closing`, `simple_fullscreen_active`, and the other transition flags on `WindowView`.

Tested on macOS 26.3.1 / Apple Silicon / `native_macos_fullscreen_mode = true`:

Before:
- Enter native fullscreen → click red dot → window vanishes, Space stays as a black screen, only Cmd+Q gets out.

After:
- Enter native fullscreen → click red dot → Space animates out, window hides, Dock click brings the window back with the same tabs and running shells. Cmd+W behavior is unchanged.

Closes #388.