### PR TITLE
fix(perf): collapse appearance reload into one cycle per system flip

### DIFF
--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -1086,6 +1086,7 @@ pub struct TermWindow {
     config_subscription: Option<config::ConfigSubscription>,
     pending_config_reload_after_resize: bool,
     silent_reload_queued: bool,
+    last_handled_appearance: Option<Appearance>,
     deferred_layout_relayout_epoch: usize,
     layout_sticky_fullscreen_until: Option<Instant>,
     closed_tab_history: std::collections::VecDeque<PathBuf>,
@@ -1577,6 +1578,7 @@ impl TermWindow {
             config_subscription: None,
             pending_config_reload_after_resize: false,
             silent_reload_queued: false,
+            last_handled_appearance: None,
             deferred_layout_relayout_epoch: 0,
             layout_sticky_fullscreen_until: None,
             closed_tab_history: std::collections::VecDeque::new(),
@@ -1867,21 +1869,11 @@ impl TermWindow {
                 Ok(true)
             }
             WindowEvent::AppearanceChanged(appearance) => {
-                log::debug!("Appearance is now {:?}", appearance);
-                // This is a bit fugly; we get per-window notifications
-                // for appearance changes which successfully updates the
-                // per-window config, but we need to explicitly tell the
-                // global config to reload, otherwise things that acces
-                // the config via config::configuration() will see the
-                // prior version of the config.
-                // What's fugly about this is that we'll reload the
-                // global config here once per window, which could
-                // be nasty for folks with a lot of windows.
-                // <https://github.com/wezterm/wezterm/issues/2295>
+                if self.last_handled_appearance == Some(appearance) {
+                    return Ok(true);
+                }
+                self.last_handled_appearance = Some(appearance);
                 config::reload();
-                // Defer per-window reload to avoid re-entrant RefCell borrow
-                // while dispatching the current window event.
-                self.schedule_silent_config_reload(window);
                 Ok(true)
             }
             WindowEvent::PerformKeyAssignment(action) => {

--- a/kaku-gui/src/termwindow/resize.rs
+++ b/kaku-gui/src/termwindow/resize.rs
@@ -306,6 +306,12 @@ impl super::TermWindow {
             return;
         }
 
+        // change_scaling below clears the font/metrics caches unconditionally,
+        // forcing a ~330ms default-font reresolve on macOS.
+        if font_scale == self.fonts.get_font_scale() && dimensions.dpi == self.fonts.get_dpi() {
+            return;
+        }
+
         let (prior_font, prior_dpi) = self.fonts.change_scaling(font_scale, dimensions.dpi);
         match RenderMetrics::new(&self.fonts) {
             Ok(metrics) => {

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -2376,7 +2376,20 @@ fn apply_window_appearance(window: &StrongPtr, config: &ConfigHandle) {
             Some(name) => msg_send![class!(NSAppearance), appearanceNamed: *nsstring(name)],
             None => nil,
         };
-        let _: () = msg_send![**window, setAppearance: appearance];
+        // setAppearance: with a new value fires viewDidChangeEffectiveAppearance
+        // on the content view, which re-enters the AppearanceChanged path.
+        let current: id = msg_send![**window, appearance];
+        let same = if appearance.is_null() && current.is_null() {
+            true
+        } else if appearance.is_null() || current.is_null() {
+            false
+        } else {
+            let eq: BOOL = msg_send![appearance, isEqual: current];
+            eq == YES
+        };
+        if !same {
+            let _: () = msg_send![**window, setAppearance: appearance];
+        }
     }
 }
 


### PR DESCRIPTION
Hi! Layered on top of #394 (`2dcf7f5`). That fix made open windows refresh on system Light/Dark changes by broadcasting `WindowEvent::AppearanceChanged` from a distributed-notification observer. Once the broadcast lands, three sources of redundant work in the reload pipeline compound into ~1.3-2s of CPU per flip on a single-window setup.

Found by instrumenting `apply_dimensions`, `config_was_reloaded_impl`, `apply_scale_change`, and the `WindowEvent::AppearanceChanged` handler with end-to-end timing logs and flipping the system theme a dozen times. Three problems show up consistently:

**Feedback loop on every flip.** `kaku-gui/src/termwindow/mod.rs:1889` calls `config::reload()`, the subscriber chain reaches `config_was_reloaded_impl`, that calls `window.config_did_change(&config)` which lands in `apply_window_appearance` (`window/src/os/macos/window.rs:2365`). The unconditional `setAppearance:` fires `viewDidChangeEffectiveAppearance` on the content view, which redispatches `AppearanceChanged` carrying the same value, and the whole pipeline re-enters. Two fixes close it from both sides:

- `apply_window_appearance` now short-circuits when `[window appearance]` already equals the target `NSAppearance` (`isEqual:`). The first reload of a real flip still triggers a single setAppearance; subsequent reloads in the same flip cycle no-op.
- `TermWindow::last_handled_appearance: Option<Appearance>` tracks the last value processed by the `AppearanceChanged` handler. If the value matches, the handler returns immediately. This catches the feedback echo when AppKit still posts the view callback for the initial real change.

**Double per-window reload.** The handler at `kaku-gui/src/termwindow/mod.rs:1877` calls `config::reload()` and then `self.schedule_silent_config_reload(window)`. `config::reload()` already fires the subscriber registered in `new_window` (`kaku-gui/src/termwindow/mod.rs:1762`), which is the canonical per-window reload path. The second schedule was a duplicate of the first — every flip ran `config_was_reloaded_impl` twice per window. Drop it.

**`apply_scale_change` always pays ~330ms.** `kaku-gui/src/termwindow/resize.rs:309` calls `FontConfiguration::change_scaling`, which unconditionally clears `self.fonts`, `self.metrics`, and `self.title_font`. The follow-up `RenderMetrics::new(&self.fonts)` re-resolves the default font from disk on macOS — 315-335ms in my traces. The `config_was_reloaded_impl` path passes the current `font_scale` and `dpi`, so the scale didn't actually change. Adding `if font_scale == self.fonts.get_font_scale() && dimensions.dpi == self.fonts.get_dpi() { return; }` makes the call a no-op when nothing changed. Other callers (resize, font scale adjust, fullscreen toggle, font-size CLI commands) pass new values, so they're unaffected.

Measured impact on MBP M4 Pro + 34" 3440×1440 external, one Kaku window:

| Step                                              | Before  | After |
|---------------------------------------------------|---------|-------|
| `AppearanceChanged` events per flip               | 2-3     | 1     |
| `config_was_reloaded_impl` runs per flip          | 2-4     | 1     |
| `apply_scale_change()` cost                       | 315-335ms | <1µs |
| Total CPU per flip                                | ~1.3-2s | ~5ms  |

Tested on macOS 26.4.1 / Apple Silicon / MBP M4 Pro + 3440×1440 / Monolisa 17pt / single-window setup with `tab_bar_at_bottom = false`, `INTEGRATED_BUTTONS|RESIZE`, `hide_tab_bar_if_only_one_tab = true`.

Here is a video of my implementation (left) and the current one on main : 
https://github.com/user-attachments/assets/a6137f5d-13e8-475d-93f7-933822502414

Closes #394