### PR TITLE
fix(ai-chat): improve ATX heading # marker contrast

### DIFF
--- a/kaku-gui/src/overlay/ai_chat/render.rs
+++ b/kaku-gui/src/overlay/ai_chat/render.rs
@@ -105,8 +105,7 @@ pub(super) fn format_tool_suffix(tools: &[ToolRef], spinner_char: &str) -> Strin
 /// Build the attribute cell for an inline span within an AI text line,
 /// honoring the enclosing block style.
 fn inline_cell(style: InlineStyle, block: BlockStyle, pal: &ChatPalette) -> CellAttributes {
-    // Heading lines use the accent (AI header) color as their base, regardless
-    // of inline style: inline emphasis inside a heading still reads naturally.
+    // Heading markers and body text use contrast-aware palette helpers.
     // Diff lines use semantic colors independent of the palette.
     if let BlockStyle::DiffAdd | BlockStyle::DiffRemove | BlockStyle::DiffHunk = block {
         let fg = match block {
@@ -121,13 +120,14 @@ fn inline_cell(style: InlineStyle, block: BlockStyle, pal: &ChatPalette) -> Cell
         return pal.make_attrs(fg, pal.bg_attr());
     }
     let base = match block {
-        BlockStyle::Heading(_) => pal.ai_header_cell(),
+        BlockStyle::Heading(_) => pal.heading_text_cell(),
         BlockStyle::Quote => pal.input_cell(), // dim fg for block-quoted text
         BlockStyle::Hr => pal.border_dim_cell(),
         BlockStyle::Code => pal.input_cell(),
         _ => pal.ai_text_cell(),
     };
     match style {
+        InlineStyle::HeadingMarker => pal.heading_marker_cell(),
         InlineStyle::Plain => base,
         InlineStyle::Bold => {
             let mut a = base;

--- a/kaku-gui/src/overlay/ai_chat/state.rs
+++ b/kaku-gui/src/overlay/ai_chat/state.rs
@@ -440,7 +440,11 @@ fn emit_assistant_markdown(
                 i += 1;
             }
             MdBlock::Heading { level, text } => {
-                let segs = tokenize_inline(text);
+                let mut segs = vec![InlineSpan {
+                    text: format!("{} ", "#".repeat(*level as usize)),
+                    style: InlineStyle::HeadingMarker,
+                }];
+                segs.extend(tokenize_inline(text));
                 let lv = *level;
                 for wrapped in wrap_segments(&segs, width) {
                     out.push(DisplayLine::Text {

--- a/kaku-gui/src/overlay/ai_chat/tests.rs
+++ b/kaku-gui/src/overlay/ai_chat/tests.rs
@@ -156,6 +156,41 @@ mod markdown_tests {
     }
 
     #[test]
+    fn heading_marker_prefixes_body_text() {
+        let mut segs = vec![InlineSpan {
+            text: "## ".to_string(),
+            style: InlineStyle::HeadingMarker,
+        }];
+        segs.extend(tokenize_inline("Section"));
+        assert_eq!(segs[0].style, InlineStyle::HeadingMarker);
+        assert_eq!(segs[0].text, "## ");
+        assert_eq!(segs[1].text, "Section");
+    }
+
+    #[test]
+    fn light_theme_heading_text_falls_back_to_foreground() {
+        let pal = ChatPalette {
+            bg: SrgbaTuple(1.0, 0.99, 0.94, 1.0),
+            fg: SrgbaTuple(0.25, 0.24, 0.23, 1.0),
+            accent: SrgbaTuple(0.0, 1.0, 1.0, 1.0),
+            border: SrgbaTuple(0.45, 0.43, 0.40, 1.0),
+            user_header: SrgbaTuple(0.8, 0.6, 0.0, 1.0),
+            user_text: SrgbaTuple(0.25, 0.24, 0.23, 1.0),
+            ai_text: SrgbaTuple(0.25, 0.24, 0.23, 1.0),
+            selection_fg: SrgbaTuple(1.0, 1.0, 1.0, 1.0),
+            selection_bg: SrgbaTuple(0.2, 0.4, 0.8, 1.0),
+        };
+        assert!(pal.is_light());
+        let marker = pal.heading_marker_cell();
+        let text = pal.heading_text_cell();
+        assert_ne!(
+            format!("{:?}", marker.foreground()),
+            format!("{:?}", text.foreground()),
+            "marker and body should use distinct colors"
+        );
+    }
+
+    #[test]
     fn block_fenced_code_captures_inner() {
         let blocks = parse_markdown_blocks("```rust\nfn main() {}\n```");
         let code_lines: Vec<&str> = blocks

--- a/kaku-gui/src/overlay/ai_chat/types.rs
+++ b/kaku-gui/src/overlay/ai_chat/types.rs
@@ -17,15 +17,62 @@ pub struct ChatPalette {
     pub selection_bg: SrgbaTuple,
 }
 
+fn palette_luminance(color: SrgbaTuple) -> f32 {
+    0.2126 * color.0 + 0.7152 * color.1 + 0.0722 * color.2
+}
+
+fn palette_has_separation(bg: SrgbaTuple, fg: SrgbaTuple) -> bool {
+    (palette_luminance(bg) - palette_luminance(fg)).abs() >= 0.15
+}
+
+fn palette_blend(a: SrgbaTuple, b: SrgbaTuple, amount: f32) -> SrgbaTuple {
+    let amount = amount.clamp(0.0, 1.0);
+    SrgbaTuple(
+        a.0 + (b.0 - a.0) * amount,
+        a.1 + (b.1 - a.1) * amount,
+        a.2 + (b.2 - a.2) * amount,
+        1.0,
+    )
+}
+
 impl ChatPalette {
     /// True when the chat background reads as a light color, using ITU-R BT.709
     /// relative luminance. Used to pick light-mode-appropriate accents (e.g.
     /// the syntect theme for fenced code blocks).
     pub(crate) fn is_light(&self) -> bool {
-        let r = self.bg.0;
-        let g = self.bg.1;
-        let b = self.bg.2;
-        0.2126 * r + 0.7152 * g + 0.0722 * b > 0.5
+        palette_luminance(self.bg) > 0.5
+    }
+
+    /// ATX heading `#` markers: muted against the chat background but still
+    /// readable on both light and dark themes.
+    fn heading_marker_attr(&self) -> ColorAttribute {
+        let anchor = if self.is_light() {
+            palette_blend(self.bg, self.fg, 0.42)
+        } else {
+            palette_blend(self.bg, self.fg, 0.5)
+        };
+        let candidate = if palette_has_separation(self.bg, self.border) {
+            self.border
+        } else {
+            anchor
+        };
+        let fg = if palette_has_separation(self.bg, candidate) {
+            candidate
+        } else {
+            anchor
+        };
+        ColorAttribute::TrueColorWithDefaultFallback(fg)
+    }
+
+    /// Heading body text: prefer the accent when it separates from the
+    /// background, otherwise fall back to bold foreground.
+    fn heading_text_attr(&self) -> ColorAttribute {
+        let fg = if palette_has_separation(self.bg, self.accent) {
+            self.accent
+        } else {
+            self.fg
+        };
+        ColorAttribute::TrueColorWithDefaultFallback(fg)
     }
 
     pub(super) fn bg_attr(&self) -> ColorAttribute {
@@ -76,6 +123,12 @@ impl ChatPalette {
     }
     pub fn ai_header_cell(&self) -> CellAttributes {
         self.make_attrs_bold(self.accent_attr(), self.bg_attr())
+    }
+    pub(crate) fn heading_marker_cell(&self) -> CellAttributes {
+        self.make_attrs(self.heading_marker_attr(), self.bg_attr())
+    }
+    pub(crate) fn heading_text_cell(&self) -> CellAttributes {
+        self.make_attrs_bold(self.heading_text_attr(), self.bg_attr())
     }
     pub fn ai_text_cell(&self) -> CellAttributes {
         self.make_attrs(self.ai_text_attr(), self.bg_attr())
@@ -310,6 +363,8 @@ pub(crate) enum InlineStyle {
     Bold,
     Italic,
     Code,
+    /// ATX heading `#` prefix rendered before the heading body text.
+    HeadingMarker,
     Highlighted(u8, u8, u8),
 }
 


### PR DESCRIPTION
## Summary
- Render ATX markdown heading `#` prefixes again in the AI chat overlay instead of stripping them during parse
- Add contrast-aware `heading_marker_cell()` and `heading_text_cell()` helpers on `ChatPalette`, reusing existing palette tokens with background-aware fallbacks
- On light themes where accent cyan lacks separation from the background, heading body text falls back to bold foreground

partially addresses #404

## Test plan
- [x] `cargo build -p kaku-gui` (zero warnings)
- [x] `cargo test -p kaku-gui overlay::ai_chat`
- [ ] Manual: open Cmd+L AI chat on light and dark themes, confirm `#` markers and heading text are readable