### PR TITLE
[codex] guard setup_zsh update-only init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
             assets/shell-integration/tests/z_jump_provider_smoke.sh
             assets/shell-integration/tests/yazi_theme_smoke.sh
             assets/shell-integration/tests/starship_rprompt_smoke.sh
+            assets/shell-integration/tests/setup_zsh_update_only_smoke.sh
             assets/shell-integration/tests/kiro_autosuggest_compat_smoke.sh
             assets/shell-integration/tests/cmd_backspace_binding_smoke.sh
             assets/shell-integration/tests/fish_ai_query_clear_smoke.sh

--- a/assets/shell-integration/tests/setup_zsh_update_only_smoke.sh
+++ b/assets/shell-integration/tests/setup_zsh_update_only_smoke.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHELL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SHELL_DIR/../.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/kaku-setup-zsh-smoke.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+tmp_home="$tmp_dir/home"
+tmp_vendor="$tmp_dir/vendor"
+mkdir -p "$tmp_home" "$tmp_vendor"
+
+for plugin in fast-syntax-highlighting zsh-autosuggestions zsh-completions zsh-z; do
+  mkdir -p "$tmp_vendor/$plugin"
+done
+
+if [[ -f "$REPO_ROOT/assets/vendor/starship.toml" ]]; then
+  cp "$REPO_ROOT/assets/vendor/starship.toml" "$tmp_vendor/starship.toml"
+else
+  printf '# test starship config\n' >"$tmp_vendor/starship.toml"
+fi
+
+output_log="$tmp_dir/output.log"
+error_log="$tmp_dir/error.log"
+
+if ! HOME="$tmp_home" \
+  KAKU_INIT_INTERNAL=1 \
+  KAKU_SKIP_TOOL_BOOTSTRAP=1 \
+  KAKU_SKIP_TERMINFO_BOOTSTRAP=1 \
+  KAKU_VENDOR_DIR="$tmp_vendor" \
+  bash "$SHELL_DIR/setup_zsh.sh" --update-only >"$output_log" 2>"$error_log"; then
+  cat "$output_log" >&2
+  cat "$error_log" >&2
+  fail "setup_zsh.sh --update-only failed"
+fi
+
+if grep -Fq "local: can only be used in a function" "$output_log" "$error_log"; then
+  cat "$output_log" >&2
+  cat "$error_log" >&2
+  fail "setup_zsh.sh used local outside a function"
+fi
+
+[[ -f "$tmp_home/.config/starship.toml" ]] || fail "starship.toml was not initialized"
+[[ -f "$tmp_home/.config/kaku/zsh/kaku.zsh" ]] || fail "kaku.zsh was not generated"
+[[ -f "$tmp_home/.zshrc" ]] || fail ".zshrc was not patched"
+
+echo "setup_zsh update-only smoke test passed"


### PR DESCRIPTION
## Summary

- Add an isolated `setup_zsh.sh --update-only` smoke test that runs with a temporary HOME and stub vendor plugin directories.
- Wire the smoke test into the existing shell integration CI list.
- The runtime fix for the reported `local` failure is already on `main` in `28a5e06`; this PR adds regression coverage for the same path.

## Root Cause

`setup_zsh.sh` previously declared `local starship_dir` in the script's top-level Starship config copy block. When `~/.config/starship.toml` did not exist, bash executed that top-level `local` and aborted with `local: can only be used in a function`.

#396 reports the same failure mode and stack location as #405.

## Validation

- `bash assets/shell-integration/tests/setup_zsh_update_only_smoke.sh`
- Existing shell integration smoke-test loop with the new test included
- `shellcheck -f gcc assets/shell-integration/tests/setup_zsh_update_only_smoke.sh`
- Checked all shell scripts for `SC2168`; no matches

Closes #405
Closes #396
