### PR TITLE
[codex] fix macos window geometry edge cases

### DIFF
--- a/kaku-gui/src/termwindow/mouseevent.rs
+++ b/kaku-gui/src/termwindow/mouseevent.rs
@@ -83,6 +83,12 @@ fn tab_bar_item_starts_window_drag(item: TabBarItem) -> bool {
     )
 }
 
+fn should_use_manual_window_drag(window_state: WindowState) -> bool {
+    cfg!(target_os = "macos")
+        && window_state.contains(WindowState::MAXIMIZED)
+        && !window_state.contains(WindowState::FULL_SCREEN)
+}
+
 fn should_preserve_tmux_bypass_reporting(
     is_wheel_event: bool,
     modifiers: window::Modifiers,
@@ -756,13 +762,12 @@ impl super::TermWindow {
                 // Event landed in title/padding area above terminal content but missed all UI items.
                 match event.kind {
                     WMEK::Press(MousePress::Left) => {
-                        let maximized = self
-                            .window_state
-                            .intersects(WindowState::MAXIMIZED | WindowState::FULL_SCREEN);
+                        let fullscreen = self.window_state.contains(WindowState::FULL_SCREEN);
+                        let maximized = self.window_state.contains(WindowState::MAXIMIZED);
                         // Double-click title area to zoom window
                         if self.last_mouse_click.as_ref().map(|c| c.streak) == Some(2) {
                             if let Some(ref window) = self.window {
-                                if maximized {
+                                if maximized || fullscreen {
                                     window.restore();
                                 } else {
                                     window.maximize();
@@ -772,10 +777,14 @@ impl super::TermWindow {
                         }
                         self.current_mouse_capture = Some(MouseCapture::UI);
                         self.window_drag.is_window_dragging = true;
-                        if !maximized && !cfg!(target_os = "macos") {
+                        if should_use_manual_window_drag(self.window_state)
+                            || (!maximized && !fullscreen && !cfg!(target_os = "macos"))
+                        {
                             self.window_drag.position.replace(event.clone());
                         }
-                        context.request_drag_move();
+                        if !should_use_manual_window_drag(self.window_state) {
+                            context.request_drag_move();
+                        }
                         return;
                     }
                     WMEK::Move if self.current_mouse_capture.is_none() => {
@@ -1074,15 +1083,14 @@ impl super::TermWindow {
                     }
                     TabBarItem::None | TabBarItem::LeftStatus | TabBarItem::RightStatus => {
                         self.tab_drag_state = None;
-                        let maximized = self
-                            .window_state
-                            .intersects(WindowState::MAXIMIZED | WindowState::FULL_SCREEN);
+                        let fullscreen = self.window_state.contains(WindowState::FULL_SCREEN);
+                        let maximized = self.window_state.contains(WindowState::MAXIMIZED);
                         if let Some(ref window) = self.window {
                             if should_zoom_title_area(
                                 self.config.window_decorations,
                                 self.last_mouse_click.as_ref().map(|c| c.streak),
                             ) {
-                                if maximized {
+                                if maximized || fullscreen {
                                     window.restore();
                                 } else {
                                     window.maximize();
@@ -1091,10 +1099,14 @@ impl super::TermWindow {
                             }
                         }
                         self.window_drag.is_window_dragging = true;
-                        if !maximized && !cfg!(target_os = "macos") {
+                        if should_use_manual_window_drag(self.window_state)
+                            || (!maximized && !fullscreen && !cfg!(target_os = "macos"))
+                        {
                             self.window_drag.position.replace(event.clone());
                         }
-                        context.request_drag_move();
+                        if !should_use_manual_window_drag(self.window_state) {
+                            context.request_drag_move();
+                        }
                     }
                     TabBarItem::WindowButton(button) => {
                         self.tab_drag_state = None;
@@ -1869,15 +1881,17 @@ fn wmek_to_tmek_and_button(event: &MouseEvent) -> (TMEK, TMB) {
 mod tests {
     use super::{
         mouse_dispatch_target, should_bypass_wheel_assignment_in_alt,
-        should_preserve_tmux_bypass_reporting, should_zoom_title_area,
-        tab_bar_item_starts_window_drag, wheel_during_terminal_selection_action,
-        MouseDispatchTarget, SelectionDragWheelAction,
+        should_preserve_tmux_bypass_reporting, should_use_manual_window_drag,
+        should_zoom_title_area, tab_bar_item_starts_window_drag,
+        wheel_during_terminal_selection_action, MouseDispatchTarget, SelectionDragWheelAction,
     };
     use crate::tabbar::TabBarItem;
     use crate::termwindow::MouseCapture;
     use config::SelectionWheelScrollBehavior;
     use mux::pane::PaneId;
-    use window::{IntegratedTitleButton, Modifiers, MouseButtons, MousePress, WindowDecorations};
+    use window::{
+        IntegratedTitleButton, Modifiers, MouseButtons, MousePress, WindowDecorations, WindowState,
+    };
 
     #[test]
     fn terminal_capture_keeps_release_routed_to_terminal() {
@@ -1937,6 +1951,18 @@ mod tests {
         assert!(tab_bar_item_starts_window_drag(TabBarItem::None));
         assert!(tab_bar_item_starts_window_drag(TabBarItem::LeftStatus));
         assert!(tab_bar_item_starts_window_drag(TabBarItem::RightStatus));
+    }
+
+    #[test]
+    fn macos_maximized_window_drag_uses_manual_path() {
+        if cfg!(target_os = "macos") {
+            assert!(should_use_manual_window_drag(WindowState::MAXIMIZED));
+            assert!(!should_use_manual_window_drag(
+                WindowState::MAXIMIZED | WindowState::FULL_SCREEN
+            ));
+        } else {
+            assert!(!should_use_manual_window_drag(WindowState::MAXIMIZED));
+        }
     }
 
     #[test]

--- a/kaku-gui/src/termwindow/render/tab_bar.rs
+++ b/kaku-gui/src/termwindow/render/tab_bar.rs
@@ -65,9 +65,15 @@ impl crate::TermWindow {
 
         let palette = self.palette().clone();
 
-        // Natural metrics keep the single-line bar from inheriting the
-        // terminal's line_height padding.
-        let tab_metrics = RenderMetrics::with_font_metrics(&self.fonts.default_font()?.metrics());
+        let tab_metrics = if self.config.tab_bar_at_bottom {
+            // Bottom tabs have no rounded titlebar mask above them, so keep the
+            // compact natural height used by earlier releases.
+            RenderMetrics::with_font_metrics(&self.fonts.default_font()?.metrics())
+        } else {
+            // Top tabs sit under the macOS titlebar mask; honor line_height so
+            // tall fonts don't clip against the top edge.
+            self.render_metrics
+        };
 
         self.ui_items.append(&mut self.tab_bar.compute_ui_items(
             tab_bar_y as usize,
@@ -173,8 +179,10 @@ impl crate::TermWindow {
         if config.use_fancy_tab_bar {
             let font = fontconfig.title_font()?;
             Ok((font.metrics().cell_height.get() as f32 * 1.75).ceil())
-        } else {
+        } else if config.tab_bar_at_bottom {
             Ok(render_metrics.natural_cell_height as f32)
+        } else {
+            Ok(render_metrics.cell_size.height as f32)
         }
     }
 
@@ -192,8 +200,10 @@ impl crate::TermWindow {
             // the terminal cell height as a stand-in for the title font cell
             // height. The two differ by ~1-2 pixels in typical configs.
             (render_metrics.cell_size.height as f32 * 1.75).ceil()
-        } else {
+        } else if config.tab_bar_at_bottom {
             render_metrics.natural_cell_height as f32
+        } else {
+            render_metrics.cell_size.height as f32
         }
     }
 

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -682,6 +682,58 @@ fn window_fills_visible_frame(window: id) -> bool {
     }
 }
 
+fn fit_frame_to_visible_frame(frame: NSRect, visible_frame: NSRect) -> Option<NSRect> {
+    if visible_frame.size.width <= 0.0 || visible_frame.size.height <= 0.0 {
+        return None;
+    }
+
+    let mut adjusted = frame;
+    adjusted.size.width = adjusted.size.width.min(visible_frame.size.width);
+    adjusted.size.height = adjusted.size.height.min(visible_frame.size.height);
+
+    let visible_max_x = visible_frame.origin.x + visible_frame.size.width;
+    let visible_max_y = visible_frame.origin.y + visible_frame.size.height;
+
+    if adjusted.origin.x < visible_frame.origin.x {
+        adjusted.origin.x = visible_frame.origin.x;
+    }
+    if adjusted.origin.y < visible_frame.origin.y {
+        adjusted.origin.y = visible_frame.origin.y;
+    }
+    if adjusted.origin.x + adjusted.size.width > visible_max_x {
+        adjusted.origin.x = visible_max_x - adjusted.size.width;
+    }
+    if adjusted.origin.y + adjusted.size.height > visible_max_y {
+        adjusted.origin.y = visible_max_y - adjusted.size.height;
+    }
+
+    if nsrect_approx_eq(frame, adjusted, 0.5) {
+        None
+    } else {
+        Some(adjusted)
+    }
+}
+
+fn visible_frame_for_window(window: id) -> Option<NSRect> {
+    if window.is_null() {
+        return None;
+    }
+
+    unsafe {
+        let screen: id = msg_send![window, screen];
+        let screen = if screen.is_null() {
+            NSScreen::mainScreen(nil)
+        } else {
+            screen
+        };
+        if screen.is_null() {
+            None
+        } else {
+            Some(msg_send![screen, visibleFrame])
+        }
+    }
+}
+
 fn window_size(window: *mut Object) -> PersistedWindowSize {
     unsafe {
         let frame = NSWindow::frame(window);
@@ -2041,31 +2093,18 @@ impl WindowInner {
                         // restored after a monitor disconnection.
                         inner.apply_decorations();
 
-                        // If the window's top edge landed outside every
-                        // visible screen (e.g. the monitor it was on got
-                        // unplugged), move it to the center of the main
-                        // screen so the title bar stays reachable.
+                        // Display topology changes can leave a window with a
+                        // frame from the old screen. Clamp both origin and size
+                        // to the new visible frame so the title bar and content
+                        // stay reachable.
                         unsafe {
                             let frame = NSWindow::frame(*inner.window);
-                            let top_left_x = frame.origin.x;
-                            let top_left_y = frame.origin.y + frame.size.height;
-                            let screens = NSScreen::screens(nil);
-                            let count = screens.count();
-                            let mut on_screen = false;
-                            for idx in 0..count {
-                                let screen = screens.objectAtIndex(idx);
-                                let sf: NSRect = msg_send![screen, visibleFrame];
-                                if top_left_x >= sf.origin.x
-                                    && top_left_x <= sf.origin.x + sf.size.width
-                                    && top_left_y >= sf.origin.y
-                                    && top_left_y <= sf.origin.y + sf.size.height
+                            if let Some(visible_frame) = visible_frame_for_window(*inner.window) {
+                                if let Some(adjusted) =
+                                    fit_frame_to_visible_frame(frame, visible_frame)
                                 {
-                                    on_screen = true;
-                                    break;
+                                    inner.window.setFrame_display_(adjusted, YES);
                                 }
-                            }
-                            if !on_screen {
-                                let _: () = msg_send![*inner.window, center];
                             }
                         }
                     }
@@ -2106,8 +2145,9 @@ impl WindowInner {
             self.update_titlebar_background();
             apply_window_appearance(&self.window, &self.config);
 
-            self.window.makeKeyAndOrderFront_(nil)
+            self.window.makeKeyAndOrderFront_(nil);
         }
+        self.dispatch_resize_event();
     }
 
     fn close(&mut self) {
@@ -2217,6 +2257,13 @@ impl WindowInner {
             }
         }
     }
+
+    fn dispatch_resize_event(&mut self) {
+        unsafe {
+            WindowView::did_resize(&mut **self.view, sel!(windowDidResize:), nil);
+        }
+    }
+
     fn set_title(&mut self, title: &str) {
         let title = nsstring(title);
         unsafe {
@@ -2227,9 +2274,9 @@ impl WindowInner {
     fn set_window_level(&mut self, level: WindowLevel) {
         unsafe {
             NSWindow::setLevel_(*self.window, window_level_to_nswindow_level(level));
-            // Dispatch a resize event with the updated window state
-            WindowView::did_resize(&mut **self.view, sel!(windowDidResize:), nil);
         }
+        // Dispatch a resize event with the updated window state
+        self.dispatch_resize_event();
     }
 
     fn set_inner_size(&mut self, width: usize, height: usize) {
@@ -3452,6 +3499,32 @@ mod tests {
     }
 
     #[test]
+    fn oversized_window_frame_is_fit_to_visible_frame() {
+        let frame = NSRect::new(NSPoint::new(100.0, 100.0), NSSize::new(1920.0, 1080.0));
+        let visible = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1440.0, 900.0));
+
+        let adjusted = fit_frame_to_visible_frame(frame, visible).unwrap();
+
+        assert_eq!(adjusted.origin.x, 0.0);
+        assert_eq!(adjusted.origin.y, 0.0);
+        assert_eq!(adjusted.size.width, 1440.0);
+        assert_eq!(adjusted.size.height, 900.0);
+    }
+
+    #[test]
+    fn offscreen_window_frame_is_moved_into_visible_frame() {
+        let frame = NSRect::new(NSPoint::new(1800.0, 900.0), NSSize::new(800.0, 600.0));
+        let visible = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1440.0, 900.0));
+
+        let adjusted = fit_frame_to_visible_frame(frame, visible).unwrap();
+
+        assert_eq!(adjusted.origin.x, 640.0);
+        assert_eq!(adjusted.origin.y, 300.0);
+        assert_eq!(adjusted.size.width, 800.0);
+        assert_eq!(adjusted.size.height, 600.0);
+    }
+
+    #[test]
     fn none_decorations_use_a_borderless_window() {
         let mask = decoration_to_mask(
             WindowDecorations::NONE,
@@ -4188,7 +4261,14 @@ impl WindowView {
     extern "C" fn mouse_down(this: &mut Object, _sel: Sel, nsevent: id) {
         // Check if we're in fullscreen mode - if so, disable dragging
         let in_fullscreen = if let Some(view) = Self::get_this(this) {
-            view.inner.borrow().fullscreen.is_some()
+            let simple_fullscreen = view.inner.borrow().fullscreen.is_some();
+            let native_fullscreen = unsafe {
+                let window: id = msg_send![this as id, window];
+                window != nil
+                    && NSWindow::styleMask(window)
+                        .contains(NSWindowStyleMask::NSFullScreenWindowMask)
+            };
+            simple_fullscreen || native_fullscreen
         } else {
             false
         };


### PR DESCRIPTION
## Summary
- clamp macOS windows back into the active visible frame after display reconfiguration
- force a resize sync after AppKit shows a window so fullscreen-space/new-window backing-size changes are observed
- route maximized macOS title/tab-bar drags through Kaku's manual drag path while leaving native drag guarded
- render non-fancy top tab bars with line-height-aware metrics to avoid clipping tall fonts

## Root Cause
AppKit can change the effective NSWindow/view frame after show or display topology changes without Kaku reconciling the new backing size/frame. Separately, the native-drag guard introduced for single-click maximize prevention blocked maximized title drags, and non-fancy top tabs used natural metrics that ignored configured line_height.

## Validation
- cargo test -p window
- cargo test -p kaku-gui

Closes #402.
Closes #403.
Closes #408.
Closes #409.