### PR TITLE
fix(config): sync COLORFGBG with resolved palette

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -2060,6 +2060,19 @@ impl Config {
                 "0"
             },
         );
+
+        // Recompute COLORFGBG from the final resolved palette so any user
+        // overrides to color_scheme are reflected in spawned child processes.
+        if let Some(bg) = self.resolved_palette.background.as_ref() {
+            cmd.env(
+                "COLORFGBG",
+                if crate::color::is_light_color(bg) {
+                    "0;15"
+                } else {
+                    "15;0"
+                },
+            );
+        }
     }
 }
 
@@ -2550,6 +2563,37 @@ mod tests {
             cmd.get_env(super::KAKU_TAB_ACCEPT_SUGGEST_FIRST),
             Some(std::ffi::OsStr::new("1"))
         );
+    }
+
+    #[test]
+    fn colorfgbg_matches_final_resolved_palette() {
+        // (background rgb, expected COLORFGBG, stale value pre-seeded via
+        // set_environment_variables that the palette must override — mirrors
+        // the bundled kaku.lua line that hard-codes COLORFGBG from the scheme
+        // name and may disagree with the final resolved background.)
+        let cases = [
+            ((232, 240, 232), "0;15", "15;0"),
+            ((21, 20, 27), "15;0", "0;15"),
+        ];
+
+        for (background, expected, stale_override) in cases {
+            let mut config = super::Config::default();
+            config.resolved_palette.background = Some(background.into());
+            config
+                .set_environment_variables
+                .insert("COLORFGBG".to_string(), stale_override.into());
+
+            let mut cmd = portable_pty::CommandBuilder::new_default_prog();
+            cmd.env_remove("COLORFGBG");
+            config.apply_cmd_defaults(&mut cmd, None, None);
+
+            assert_eq!(
+                cmd.get_env("COLORFGBG"),
+                Some(std::ffi::OsStr::new(expected)),
+                "COLORFGBG should be derived from the final resolved palette, \
+                 overriding any value set via set_environment_variables"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
### Problem

 COLORFGBG is currently set in the bundled kaku.lua based on the early config.color_scheme, but user config can still
 override color_scheme afterward in ~/.config/kaku/kaku.lua.

 That means the final theme shown by Kaku can differ from the environment exported to child processes. Tools like Pi
 use COLORFGBG to infer whether the terminal background is light or dark, so this can cause tool output styling to
 mismatch the active Kaku theme.

 ### Root cause

 This is a classic “derived state synced too early” bug:

 - bundled config sets COLORFGBG
 - user config later overrides color_scheme
 - the final UI theme and exported environment can drift apart

 ### Fix

 Recompute COLORFGBG in apply_cmd_defaults() from the final resolved palette, so spawned child processes always
 inherit the actual effective theme.

 ### Validation

 Added a unit test:

 - colorfgbg_matches_final_resolved_palette

 And verified locally with:

 - PI_RTK_BYPASS=1 cargo test -p config colorfgbg_matches_final_resolved_palette -- --nocapture
 - PI_RTK_BYPASS=1 cargo test -p config bundled_kaku_lua_defaults_missing_theme_to_appearance -- --nocapture
 - PI_RTK_BYPASS=1 cargo test -p config minimal_user_config_keeps_theme_auto_by_default -- --nocapture

 ### Notes

 This is not Pi-specific. Any child process that relies on terminal theme hints from COLORFGBG could be affected by
 the same issue.
 
### Before

 - COLORFGBG was set in bundled kaku.lua before user config overrides were applied.
 - Child processes could inherit a stale light/dark hint.
 - Tools like Pi could pick the wrong theme and render mismatched colors.

<img width="1908" height="730" alt="image" src="https://github.com/user-attachments/assets/ef5aee20-ed87-4aa3-9b06-91f2442fe264" />

 ### After

 - COLORFGBG is recomputed from the final resolved palette in apply_cmd_defaults().
 - Child processes now inherit the actual effective theme.
 - Tool rendering stays consistent with the active Kaku theme.

<img width="1694" height="732" alt="image" src="https://github.com/user-attachments/assets/9a960d48-317f-42a3-b970-b9b7916c41f6" />
