### PR TITLE
[codex] Drag maximized macOS windows natively

### DIFF
--- a/kaku-gui/src/termwindow/mouseevent.rs
+++ b/kaku-gui/src/termwindow/mouseevent.rs
@@ -84,7 +84,38 @@ fn tab_bar_item_starts_window_drag(item: TabBarItem) -> bool {
 }
 
 fn should_use_manual_window_drag(window_state: WindowState) -> bool {
-    cfg!(target_os = "macos") && !window_state.contains(WindowState::FULL_SCREEN)
+    cfg!(target_os = "macos")
+        && !window_state.intersects(WindowState::FULL_SCREEN | WindowState::MAXIMIZED)
+}
+
+fn should_use_native_maximized_window_drag(window_state: WindowState) -> bool {
+    cfg!(target_os = "macos")
+        && window_state.contains(WindowState::MAXIMIZED)
+        && !window_state.contains(WindowState::FULL_SCREEN)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TitleAreaZoomAction {
+    Maximize,
+    Restore,
+}
+
+fn title_area_double_click_zoom_action(window_state: WindowState) -> TitleAreaZoomAction {
+    if window_state.contains(WindowState::FULL_SCREEN) {
+        return TitleAreaZoomAction::Restore;
+    }
+
+    if cfg!(target_os = "macos") {
+        // NSWindow::zoom: toggles using AppKit's actual zoom state. That is more
+        // reliable than Kaku's cached WindowState after cross-screen/multi-window moves.
+        return TitleAreaZoomAction::Maximize;
+    }
+
+    if window_state.contains(WindowState::MAXIMIZED) {
+        TitleAreaZoomAction::Restore
+    } else {
+        TitleAreaZoomAction::Maximize
+    }
 }
 
 fn should_preserve_tmux_bypass_reporting(
@@ -765,10 +796,9 @@ impl super::TermWindow {
                         // Double-click title area to zoom window
                         if self.last_mouse_click.as_ref().map(|c| c.streak) == Some(2) {
                             if let Some(ref window) = self.window {
-                                if maximized || fullscreen {
-                                    window.restore();
-                                } else {
-                                    window.maximize();
+                                match title_area_double_click_zoom_action(self.window_state) {
+                                    TitleAreaZoomAction::Maximize => window.maximize(),
+                                    TitleAreaZoomAction::Restore => window.restore(),
                                 }
                             }
                             return;
@@ -781,7 +811,11 @@ impl super::TermWindow {
                             self.window_drag.position.replace(event.clone());
                         }
                         if !should_use_manual_window_drag(self.window_state) {
-                            context.request_drag_move();
+                            if should_use_native_maximized_window_drag(self.window_state) {
+                                context.request_drag_move_from_maximized();
+                            } else {
+                                context.request_drag_move();
+                            }
                         }
                         return;
                     }
@@ -1088,10 +1122,9 @@ impl super::TermWindow {
                                 self.config.window_decorations,
                                 self.last_mouse_click.as_ref().map(|c| c.streak),
                             ) {
-                                if maximized || fullscreen {
-                                    window.restore();
-                                } else {
-                                    window.maximize();
+                                match title_area_double_click_zoom_action(self.window_state) {
+                                    TitleAreaZoomAction::Maximize => window.maximize(),
+                                    TitleAreaZoomAction::Restore => window.restore(),
                                 }
                                 return;
                             }
@@ -1103,7 +1136,11 @@ impl super::TermWindow {
                             self.window_drag.position.replace(event.clone());
                         }
                         if !should_use_manual_window_drag(self.window_state) {
-                            context.request_drag_move();
+                            if should_use_native_maximized_window_drag(self.window_state) {
+                                context.request_drag_move_from_maximized();
+                            } else {
+                                context.request_drag_move();
+                            }
                         }
                     }
                     TabBarItem::WindowButton(button) => {
@@ -1880,8 +1917,10 @@ mod tests {
     use super::{
         mouse_dispatch_target, should_bypass_wheel_assignment_in_alt,
         should_preserve_tmux_bypass_reporting, should_use_manual_window_drag,
-        should_zoom_title_area, tab_bar_item_starts_window_drag,
+        should_use_native_maximized_window_drag, should_zoom_title_area,
+        tab_bar_item_starts_window_drag, title_area_double_click_zoom_action,
         wheel_during_terminal_selection_action, MouseDispatchTarget, SelectionDragWheelAction,
+        TitleAreaZoomAction,
     };
     use crate::tabbar::TabBarItem;
     use crate::termwindow::MouseCapture;
@@ -1933,6 +1972,29 @@ mod tests {
     }
 
     #[test]
+    fn macos_title_area_double_click_uses_appkit_zoom_toggle() {
+        if cfg!(target_os = "macos") {
+            assert_eq!(
+                title_area_double_click_zoom_action(WindowState::empty()),
+                TitleAreaZoomAction::Maximize
+            );
+            assert_eq!(
+                title_area_double_click_zoom_action(WindowState::MAXIMIZED),
+                TitleAreaZoomAction::Maximize
+            );
+            assert_eq!(
+                title_area_double_click_zoom_action(WindowState::FULL_SCREEN),
+                TitleAreaZoomAction::Restore
+            );
+        } else {
+            assert_eq!(
+                title_area_double_click_zoom_action(WindowState::MAXIMIZED),
+                TitleAreaZoomAction::Restore
+            );
+        }
+    }
+
+    #[test]
     fn tab_bar_tabs_and_controls_do_not_start_window_drags() {
         assert!(!tab_bar_item_starts_window_drag(TabBarItem::Tab {
             tab_idx: 1,
@@ -1955,12 +2017,31 @@ mod tests {
     fn macos_title_window_drag_uses_manual_path_except_fullscreen() {
         if cfg!(target_os = "macos") {
             assert!(should_use_manual_window_drag(WindowState::empty()));
-            assert!(should_use_manual_window_drag(WindowState::MAXIMIZED));
+            assert!(!should_use_manual_window_drag(WindowState::MAXIMIZED));
             assert!(!should_use_manual_window_drag(
                 WindowState::MAXIMIZED | WindowState::FULL_SCREEN
             ));
         } else {
             assert!(!should_use_manual_window_drag(WindowState::MAXIMIZED));
+        }
+    }
+
+    #[test]
+    fn macos_maximized_drag_uses_native_window_drag() {
+        if cfg!(target_os = "macos") {
+            assert!(should_use_native_maximized_window_drag(
+                WindowState::MAXIMIZED
+            ));
+            assert!(!should_use_native_maximized_window_drag(
+                WindowState::empty()
+            ));
+            assert!(!should_use_native_maximized_window_drag(
+                WindowState::MAXIMIZED | WindowState::FULL_SCREEN
+            ));
+        } else {
+            assert!(!should_use_native_maximized_window_drag(
+                WindowState::MAXIMIZED
+            ));
         }
     }
 

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -375,6 +375,12 @@ pub trait WindowOps {
     /// window movement on the server side (Wayland).
     fn request_drag_move(&self) {}
 
+    /// Requests a native drag for a maximized/zoomed window when the platform
+    /// can safely hand that gesture to the window manager.
+    fn request_drag_move_from_maximized(&self) {
+        self.request_drag_move();
+    }
+
     /// Signal to the windowing system that the mouse is over
     /// a window dragging area.
     ///

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -566,6 +566,7 @@ thread_local! {
     static LAST_CLOSED_WINDOW_POSITION: RefCell<Option<ScreenPoint>> = RefCell::new(None);
     // Sync drag flag: set by request_drag_move(), checked by mouse_down to execute performWindowDragWithEvent:
     static PENDING_DRAG_MOVE: Cell<bool> = Cell::new(false);
+    static PENDING_DRAG_MOVE_FROM_MAXIMIZED: Cell<bool> = Cell::new(false);
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -657,6 +658,16 @@ fn should_perform_native_window_drag(
     fills_visible_frame: bool,
 ) -> bool {
     !in_fullscreen && !is_zoomed && !fills_visible_frame
+}
+
+fn should_perform_requested_window_drag(
+    in_fullscreen: bool,
+    is_zoomed: bool,
+    fills_visible_frame: bool,
+    from_maximized: bool,
+) -> bool {
+    should_perform_native_window_drag(in_fullscreen, is_zoomed, fills_visible_frame)
+        || (!in_fullscreen && from_maximized && is_zoomed)
 }
 
 fn nsrect_approx_eq(a: NSRect, b: NSRect, tolerance: f64) -> bool {
@@ -1441,6 +1452,12 @@ impl WindowOps for Window {
         // Set flag to be checked by mouse_down and execute performWindowDragWithEvent: synchronously.
         // Avoids async dispatch to prevent modal drag loop from swallowing subsequent events.
         PENDING_DRAG_MOVE.with(|flag| flag.set(true));
+        PENDING_DRAG_MOVE_FROM_MAXIMIZED.with(|flag| flag.set(false));
+    }
+
+    fn request_drag_move_from_maximized(&self) {
+        PENDING_DRAG_MOVE.with(|flag| flag.set(true));
+        PENDING_DRAG_MOVE_FROM_MAXIMIZED.with(|flag| flag.set(true));
     }
 
     fn set_window_position(&self, coords: ScreenPoint) {
@@ -3514,6 +3531,19 @@ mod tests {
     }
 
     #[test]
+    fn requested_maximized_drag_allows_zoomed_native_drag() {
+        assert!(should_perform_requested_window_drag(
+            false, true, true, true
+        ));
+        assert!(!should_perform_requested_window_drag(
+            true, true, true, true
+        ));
+        assert!(!should_perform_requested_window_drag(
+            false, false, true, true
+        ));
+    }
+
+    #[test]
     fn oversized_window_frame_is_fit_to_visible_frame() {
         let frame = NSRect::new(NSPoint::new(100.0, 100.0), NSSize::new(1920.0, 1080.0));
         let visible = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1440.0, 900.0));
@@ -4290,6 +4320,7 @@ impl WindowView {
 
         // Clear stale flag to prevent false drag triggers from last abnormal exit
         PENDING_DRAG_MOVE.with(|flag| flag.set(false));
+        PENDING_DRAG_MOVE_FROM_MAXIMIZED.with(|flag| flag.set(false));
         Self::mouse_common(this, nsevent, MouseEventKind::Press(MousePress::Left));
 
         // Execute drag synchronously: app layer may call request_drag_move() in mouse_common to set flag
@@ -4298,16 +4329,19 @@ impl WindowView {
         // frame already fills the visible screen even if isZoomed is stale. Use double-click
         // to un-zoom instead of letting a single title-area click expand the window.
         let pending_drag = PENDING_DRAG_MOVE.with(|flag| flag.replace(false));
+        let pending_drag_from_maximized =
+            PENDING_DRAG_MOVE_FROM_MAXIMIZED.with(|flag| flag.replace(false));
         if pending_drag && !in_fullscreen {
             unsafe {
                 let window: id = msg_send![this as id, window];
                 if window != nil {
                     let is_zoomed: bool = msg_send![window, isZoomed];
                     let fills_visible_frame = window_fills_visible_frame(window);
-                    if should_perform_native_window_drag(
+                    if should_perform_requested_window_drag(
                         in_fullscreen,
                         is_zoomed,
                         fills_visible_frame,
+                        pending_drag_from_maximized,
                     ) {
                         let () = msg_send![window, performWindowDragWithEvent: nsevent];
                     }


### PR DESCRIPTION
## Summary

Fix macOS maximized window dragging so Kaku uses AppKit's native window drag path for zoomed windows instead of manually moving the frame.

## Problem

When a Kaku window was maximized on one display and dragged to another display, follow-up zoom/restore operations could jump the window back to the previous display. A restore-before-manual-move workaround fixed the display jump, but introduced visible jitter because the window was restored and manually repositioned in the same mouse-move frame.

## Root Cause

Kaku's title/tab-strip drag handling used manual `set_window_position` movement for macOS maximized windows. That moved the visible window, but AppKit still considered the window zoomed and retained its old restore frame on the previous display. Later `NSWindow::zoom:` calls then used that stale restore frame.

## Fix

- Route maximized non-fullscreen macOS title/tab-strip drags to a native AppKit drag request.
- Add `WindowOps::request_drag_move_from_maximized()` as a narrow API for this case, with a default fallback to `request_drag_move()`.
- In the macOS window backend, only allow the maximized native drag bypass when the request is explicit and AppKit reports the window is actually `isZoomed`.
- Keep ordinary non-maximized macOS title/tab-strip drags on Kaku's existing manual drag path.
- Keep fullscreen excluded from this behavior.
- Use AppKit's actual zoom toggle for title-area double-clicks on macOS, avoiding stale cached `WindowState::MAXIMIZED` decisions after cross-screen or multi-window moves.

## Tests

- `cargo test -p kaku-gui title_area_double_click`
- `cargo test -p kaku-gui macos_maximized_drag_uses_native_window_drag`
- `cargo test -p kaku-gui macos_title_window_drag_uses_manual_path_except_fullscreen`
- `cargo test -p window requested_maximized_drag_allows_zoomed_native_drag`
- `cargo test -p window native_drag_is_disabled_for_fullscreen_and_maximized_frames`
- `make app`
- Commit hook:
  - `cargo +nightly fmt -p kaku -p kaku-gui -p mux -p wezterm-term -p termwiz -p config -p wezterm-font -- --check`
  - `cargo nextest run --locked -E 'not test(shapecache::test::ligatures_jetbrains)'` (`1083 passed`, `5 skipped`)
  - `cargo nextest run --locked -p wezterm-escape-parser` (`15 passed`)

## Manual Verification

Verified locally that:

- maximized windows can be dragged without jitter,
- dragging a maximized window to another display no longer makes later zoom/restore jump back to the previous display,
- normal non-maximized title/tab-strip dragging still works.
