### PR TITLE
Handle config.show_tab_index_in_tab_bar

### DIFF
--- a/assets/macos/Kaku.app/Contents/Resources/kaku.lua
+++ b/assets/macos/Kaku.app/Contents/Resources/kaku.lua
@@ -3289,6 +3289,13 @@ wezterm.on('format-tab-title', function(tab, tabs, panes, effective_config, hove
   if active_pane and active_pane.is_zoomed then
     text = text .. ' [Z]'
   end
+  
+  -- Handle config.show_tab_index_in_tab_bar
+  if effective_config.show_tab_index_in_tab_bar then
+    local tab_index = effective_config.tab_and_split_indices_are_zero_based and tab.tab_index or (tab.tab_index + 1)
+    text = tab_index .. ":" .. text
+  end
+
   text = wezterm.truncate_right(text, math.max(8, max_width - 2))
 
   local intensity = tab.is_active and 'Bold' or 'Normal'


### PR DESCRIPTION
I have tested and confirmed that when a user's config handle [event `format-tab-title`](https://wezterm.org/config/lua/window-events/format-tab-title.html), they have to handle the `tab_index` themselves. `tab.tab_title` in the event handler never has the index prefix in it.

And there is also a note from Wezterm's doc, unlike other events, `format-tab-title` only trigger the first event handler. Therefore, userland's kaku.lua config has no way to override Kaku bundled tab title formatter.

> Only the first format-tab-title event will be executed; it doesn't make sense to define multiple instances of the event with multiple wezterm.on("format-tab-title", ...) calls.

This will resolves #397 