### PR TITLE
fix: refresh TUI palette after config reload

### DIFF
--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -2999,6 +2999,9 @@ impl TermWindow {
                     overlay.pane.set_config(Arc::clone(&term_config));
                 }
             }
+            if let Some(active_pane) = self.get_active_pane_or_overlay() {
+                active_pane.refresh_focus(self.focused.is_some());
+            }
         }
 
         if let Some(window) = self.window.as_ref().map(|w| w.clone()) {

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -533,6 +533,10 @@ impl Pane for LocalPane {
         self.terminal.lock().focus_changed(focused);
     }
 
+    fn refresh_focus(&self, focused: bool) {
+        self.terminal.lock().refresh_focus(focused);
+    }
+
     fn has_unseen_output(&self) -> bool {
         self.terminal.lock().has_unseen_output()
     }

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -343,6 +343,9 @@ pub trait Pane: Downcast + Send + Sync {
     /// Called to advise on whether this tab has focus
     fn focus_changed(&self, _focused: bool) {}
 
+    /// Prompt focus-aware TUIs to refresh terminal-scoped state.
+    fn refresh_focus(&self, _focused: bool) {}
+
     /// Called to advise remote mux that this is the active tab
     /// for the current identity
     fn advise_focus(&self) {}

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -918,15 +918,36 @@ impl TerminalState {
             }
         }
         if self.focus_tracking {
-            self.write_fmt_to_pty(
-                "focus_changed: focus-tracking response",
-                format_args!("{}{}", CSI, if focused { "I" } else { "O" }),
-            );
-            self.flush_pty("focus_changed: focus-tracking response");
+            self.write_focus_tracking_response(focused, "focus_changed: focus-tracking response");
         }
         self.focused = focused;
         if !focused {
             self.lost_focus_seqno = self.seqno;
+        }
+    }
+
+    fn write_focus_tracking_response(&mut self, focused: bool, context: &str) {
+        self.write_fmt_to_pty(
+            context,
+            format_args!("{}{}", CSI, if focused { "I" } else { "O" }),
+        );
+        self.flush_pty(context);
+    }
+
+    /// Prompt focus-aware TUIs to refresh terminal-scoped state.
+    ///
+    /// Some TUIs use focus-in as their signal to re-query OSC 10/11 default
+    /// colors. A host-side theme reload changes those values without
+    /// necessarily changing window focus, so emit a focus-in probe and, if the
+    /// pane is not actually focused, immediately restore the focus-out state.
+    pub fn refresh_focus(&mut self, focused: bool) {
+        if !self.focus_tracking {
+            return;
+        }
+
+        self.write_focus_tracking_response(true, "refresh_focus: focus-in response");
+        if !focused {
+            self.write_focus_tracking_response(false, "refresh_focus: focus-out response");
         }
     }
 

--- a/term/src/test/mod.rs
+++ b/term/src/test/mod.rs
@@ -10,7 +10,9 @@ mod csi;
 // mod selection; FIXME: port to render layer
 use crate::color::ColorPalette;
 use k9::assert_equal as assert_eq;
+use std::io::Write;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use wezterm_escape_parser::csi::{Edit, EraseInDisplay, EraseInLine};
 use wezterm_escape_parser::{OneBased, OperatingSystemCommand, CSI};
 use wezterm_surface::{CursorShape, CursorVisibility, SequenceNo, SEQ_ZERO};
@@ -59,6 +61,15 @@ impl TerminalConfiguration for TestTermConfig {
 
 impl TestTerm {
     fn new(height: usize, width: usize, scrollback: usize) -> Self {
+        Self::new_with_writer(height, width, scrollback, Box::new(Vec::new()))
+    }
+
+    fn new_with_writer(
+        height: usize,
+        width: usize,
+        scrollback: usize,
+        writer: Box<dyn Write + Send>,
+    ) -> Self {
         let _ = env_logger::Builder::new()
             .is_test(true)
             .filter_level(log::LevelFilter::Trace)
@@ -75,7 +86,7 @@ impl TestTerm {
             Arc::new(TestTermConfig { scrollback }),
             "WezTerm",
             "O_o",
-            Box::new(Vec::new()),
+            writer,
         );
         let clip: Arc<dyn Clipboard> = Arc::new(LocalClip::new());
         term.set_clipboard(&clip);
@@ -182,6 +193,46 @@ impl TestTerm {
              lines (right) reason={:?}. threshold seq: {} seqs: {:?}",
             reason, seqno, seqs
         );
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct SharedWriter {
+    output: Arc<Mutex<Vec<u8>>>,
+}
+
+impl SharedWriter {
+    fn snapshot(&self) -> Vec<u8> {
+        self.output.lock().unwrap().clone()
+    }
+
+    fn clear(&self) {
+        self.output.lock().unwrap().clear();
+    }
+}
+
+impl Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.output.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn wait_for_writer_output(writer: &SharedWriter, expected: &[u8]) {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        let actual = writer.snapshot();
+        if actual == expected {
+            return;
+        }
+        if Instant::now() >= deadline {
+            assert_eq!(actual.as_slice(), expected);
+        }
+        std::thread::sleep(Duration::from_millis(5));
     }
 }
 
@@ -1618,4 +1669,30 @@ fn test_alternate_scroll_mode_cleared_on_soft_reset() {
 
     term.soft_reset();
     assert!(!term.is_mouse_grabbed());
+}
+
+#[test]
+fn refresh_focus_pulses_focus_in_and_restores_unfocused_state() {
+    let writer = SharedWriter::default();
+    let mut term = TestTerm::new_with_writer(5, 10, 100, Box::new(writer.clone()));
+
+    term.set_mode("?1004", true);
+    term.focus_changed(false);
+    wait_for_writer_output(&writer, b"\x1b[O");
+
+    writer.clear();
+    term.refresh_focus(false);
+
+    wait_for_writer_output(&writer, b"\x1b[I\x1b[O");
+}
+
+#[test]
+fn refresh_focus_sends_only_focus_in_when_already_focused() {
+    let writer = SharedWriter::default();
+    let mut term = TestTerm::new_with_writer(5, 10, 100, Box::new(writer.clone()));
+
+    term.set_mode("?1004", true);
+    term.refresh_focus(true);
+
+    wait_for_writer_output(&writer, b"\x1b[I");
 }


### PR DESCRIPTION
## Summary

- send a focus-in refresh pulse to the active pane after config reload so focus-aware TUIs can re-query terminal default colors
- preserve the real focus state by sending focus-out again when the window is not focused
- add terminal-state tests for the focused and unfocused refresh paths

## Why

Some TUIs cache OSC 10/11 default foreground/background colors and only re-query them on focus gain. When Kaku reloads config after a system light/dark appearance change, the terminal palette changes but those TUIs can keep using the old cached default background until the user clicks back into the window. This makes theme-derived UI backgrounds render with the wrong contrast.

## Test plan

- cargo test -p wezterm-term refresh_focus
- cargo fmt --check
- cargo check -p kaku-gui