### PR TITLE
fix(ai): bypass system proxy for private/loopback hosts

### DIFF
--- a/config/src/proxy.rs
+++ b/config/src/proxy.rs
@@ -92,6 +92,75 @@ fn is_valid_host(s: &str) -> bool {
     !s.is_empty() && !s.chars().any(|c| c.is_whitespace() || c == '/' || c == ':')
 }
 
+/// Detect the macOS system proxy bypass list (`scutil --proxy` ExceptionsList).
+///
+/// These are the hosts the user marked "Bypass proxy settings for these Hosts"
+/// in Network Settings. Entries are normalized into reqwest `NoProxy` syntax
+/// (partial CIDR masks like `169.254/16` are expanded to `169.254.0.0/16`).
+/// Returns an empty vec on non-macOS or when no exceptions are configured.
+pub fn system_proxy_exceptions() -> Vec<String> {
+    let out = match Command::new("/usr/sbin/scutil").arg("--proxy").output() {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+    parse_scutil_exceptions(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Parse the `ExceptionsList` array out of `scutil --proxy` output and
+/// normalize each entry for reqwest `NoProxy::from_string`.
+pub fn parse_scutil_exceptions(text: &str) -> Vec<String> {
+    let mut entries = Vec::new();
+    let mut in_list = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if !in_list {
+            if trimmed.starts_with("ExceptionsList") && trimmed.contains('{') {
+                in_list = true;
+            }
+            continue;
+        }
+        if trimmed.starts_with('}') {
+            break;
+        }
+        // Entries look like `0 : *.local`.
+        if let Some((_, val)) = trimmed.split_once(" : ") {
+            let val = val.trim();
+            if !val.is_empty() {
+                entries.push(normalize_no_proxy_entry(val));
+            }
+        }
+    }
+    entries
+}
+
+/// Convert a macOS proxy-exception entry into reqwest `NoProxy` syntax.
+///
+/// macOS writes `*.local` for "this domain and subdomains" and abbreviated
+/// CIDRs like `169.254/16` or `10/8`. reqwest expects `.local` and full
+/// dotted CIDRs (`169.254.0.0/16`). Domains, wildcards (`*`), and already
+/// well-formed IPs pass through unchanged.
+fn normalize_no_proxy_entry(entry: &str) -> String {
+    if let Some(rest) = entry.strip_prefix("*.") {
+        return format!(".{rest}");
+    }
+    let Some((ip, mask)) = entry.split_once('/') else {
+        return entry.to_string();
+    };
+    // Only pad dotted IPv4-style addresses; leave IPv6 and anything odd alone.
+    let is_dotted_ipv4 = !ip.contains(':')
+        && ip
+            .split('.')
+            .all(|o| !o.is_empty() && o.bytes().all(|b| b.is_ascii_digit()));
+    let mut octets: Vec<&str> = ip.split('.').collect();
+    if !is_dotted_ipv4 || octets.len() >= 4 {
+        return entry.to_string();
+    }
+    while octets.len() < 4 {
+        octets.push("0");
+    }
+    format!("{}/{}", octets.join("."), mask)
+}
+
 /// Apply `proxy` to `cmd` by setting the standard curl proxy env vars.
 /// No-op when `proxy` is `None`.
 pub fn apply_to_command(cmd: &mut Command, proxy: &Option<String>) {
@@ -107,7 +176,43 @@ pub fn apply_to_command(cmd: &mut Command, proxy: &Option<String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_scutil_proxy;
+    use super::{normalize_no_proxy_entry, parse_scutil_exceptions, parse_scutil_proxy};
+
+    #[test]
+    fn normalizes_macos_exception_forms() {
+        assert_eq!(normalize_no_proxy_entry("169.254/16"), "169.254.0.0/16");
+        assert_eq!(normalize_no_proxy_entry("10/8"), "10.0.0.0/8");
+        assert_eq!(normalize_no_proxy_entry("*.local"), ".local");
+        // Already well-formed entries pass through untouched.
+        assert_eq!(normalize_no_proxy_entry("192.168.1.0/24"), "192.168.1.0/24");
+        assert_eq!(normalize_no_proxy_entry("example.com"), "example.com");
+        assert_eq!(normalize_no_proxy_entry("100.65.0.14"), "100.65.0.14");
+    }
+
+    #[test]
+    fn parses_scutil_exceptions_list() {
+        let text = r#"
+<dictionary> {
+  ExceptionsList : <array> {
+    0 : *.local
+    1 : 169.254/16
+  }
+  SOCKSEnable : 1
+  SOCKSPort : 7070
+  SOCKSProxy : 100.65.0.2
+}
+"#;
+        assert_eq!(
+            parse_scutil_exceptions(text),
+            vec![".local".to_string(), "169.254.0.0/16".to_string()]
+        );
+    }
+
+    #[test]
+    fn parses_no_exceptions_when_list_absent() {
+        let text = "<dictionary> {\n  SOCKSEnable : 1\n}\n";
+        assert!(parse_scutil_exceptions(text).is_empty());
+    }
 
     #[test]
     fn prefers_https_then_http_then_socks() {

--- a/kaku-gui/src/ai_client.rs
+++ b/kaku-gui/src/ai_client.rs
@@ -361,7 +361,16 @@ pub(crate) fn build_client_with_proxy(timeout: std::time::Duration) -> reqwest::
     if let Some(proxy_url) = config::proxy::detect_system_proxy() {
         match reqwest::Proxy::all(&proxy_url) {
             Ok(proxy) => {
-                log::info!("HTTP client using system proxy: {}", proxy_url);
+                // Bypass the proxy for loopback/LAN/CGNAT ranges so a
+                // self-hosted model server stays reachable. Critical because
+                // reqwest is built without the `socks` feature, so forcing a
+                // SOCKS proxy onto an internal `base_url` fails the request
+                // outright ("error sending request for url").
+                let proxy = proxy.no_proxy(build_no_proxy());
+                log::info!(
+                    "HTTP client using system proxy: {} (private-range bypass enabled)",
+                    proxy_url
+                );
                 builder = builder.proxy(proxy);
             }
             Err(e) => log::warn!(
@@ -376,6 +385,45 @@ pub(crate) fn build_client_with_proxy(timeout: std::time::Duration) -> reqwest::
         log::warn!("Failed to build HTTP client: {e}; falling back to default client");
         reqwest::blocking::Client::new()
     })
+}
+
+/// Hosts and ranges that must bypass any system proxy and connect directly.
+///
+/// A user with a global SOCKS/HTTP proxy still needs to reach a self-hosted
+/// model server on loopback, their LAN, or a CGNAT/Tailscale address. The list
+/// combines hard-coded private/loopback ranges, the `NO_PROXY` environment
+/// variable, and the macOS `scutil` ExceptionsList. Returns `None` only if the
+/// joined list is unparseable, which leaves the proxy applied as before.
+fn build_no_proxy() -> Option<reqwest::NoProxy> {
+    let mut entries: Vec<String> = [
+        "localhost",
+        "127.0.0.0/8",
+        "::1",
+        "169.254.0.0/16",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "100.64.0.0/10",
+        ".local",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    for var in ["NO_PROXY", "no_proxy"] {
+        if let Ok(v) = std::env::var(var) {
+            entries.extend(
+                v.split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string),
+            );
+        }
+    }
+
+    entries.extend(config::proxy::system_proxy_exceptions());
+
+    reqwest::NoProxy::from_string(&entries.join(","))
 }
 
 /// Process-level HTTP client shared across all overlay sessions.


### PR DESCRIPTION
Fixes #466

### Problem

When a macOS system proxy is configured, a self-hosted model server reachable only over loopback / LAN / CGNAT becomes unreachable. `build_client_with_proxy` applied the detected proxy to every AI request via `reqwest::Proxy::all()` with no bypass list, and reqwest is built without the `socks` feature, so a system SOCKS proxy failed the request outright (`error sending request for url ...`) even though the server was directly reachable. `detect_system_proxy()` also ignored the `scutil` ExceptionsList and the `NO_PROXY` env var, so even internal hosts were force-proxied.

### Fix

Attach a reqwest `NoProxy` bypass to the proxied client, covering:

- loopback / link-local / RFC1918 private ranges + `100.64.0.0/10` (CGNAT/Tailscale) + `.local`
- the `NO_PROXY` / `no_proxy` env var
- the macOS `scutil` ExceptionsList

Abbreviated macOS CIDR forms (`169.254/16`) and `*.local` are normalized into reqwest `NoProxy` syntax.

**Files**
- `config/src/proxy.rs` — `system_proxy_exceptions()`, `parse_scutil_exceptions()`, `normalize_no_proxy_entry()` + unit tests
- `kaku-gui/src/ai_client.rs` — `build_no_proxy()` and wiring into `build_client_with_proxy`

**Note:** this intentionally does *not* add reqwest's `socks` feature. Routing an internal `base_url` through a SOCKS proxy is the wrong behavior; bypassing it is the fix. SOCKS support for *external* API hosts can be a separate follow-up.

### Test plan

- [x] `make check`
- [x] `make test` (full workspace via nextest)
- [x] `cargo +nightly fmt --check` clean, `cargo clippy` clean
- [x] 3 new unit tests in `config` (CIDR/exception normalization)
- [x] End-to-end: with a macOS system SOCKS proxy enabled, `k "..."` now reaches an internal server that previously failed with `error sending request`
- [ ] Maintainer to confirm no regression for users who rely on the proxy for *external* API hosts (those still route through the proxy as before)