### PR TITLE
fix(ai-tools): guard fs_patch against unbounded file read

### DIFF
--- a/kaku-gui/src/ai_tools/fs.rs
+++ b/kaku-gui/src/ai_tools/fs.rs
@@ -6,6 +6,30 @@ use std::path::PathBuf;
 
 use super::paths::{reject_if_sensitive, reject_relative_cwd_escape, resolve};
 
+/// Maximum size of a file `fs_patch` will load into memory. Patching needs the
+/// whole file in memory (the replacement scans the full content), so unlike
+/// `fs_read` it cannot truncate. Hand-written source files stay well under this;
+/// the cap exists to refuse multi-hundred-MB build artifacts, logs, datasets, or
+/// checked-in binaries before `read_to_string` allocates their full contents.
+const MAX_PATCH_FILE_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Reject a patch target whose on-disk size exceeds `limit` bytes, before any
+/// read allocates the full file. Returns the file length when within budget.
+fn ensure_patchable_size(path: &std::path::Path, limit: u64) -> Result<u64> {
+    let len = std::fs::metadata(path)
+        .with_context(|| format!("stat {}", path.display()))?
+        .len();
+    if len > limit {
+        anyhow::bail!(
+            "{} is {} bytes, exceeds fs_patch limit of {} bytes",
+            path.display(),
+            len,
+            limit
+        );
+    }
+    Ok(len)
+}
+
 pub(super) fn exec_fs_read(args: &serde_json::Value, cwd: &str, cap: usize) -> Result<String> {
     let raw_path = args["path"].as_str().context("missing path")?;
     let path = resolve(raw_path, cwd)?;
@@ -107,6 +131,7 @@ pub(super) fn exec_fs_patch(args: &serde_json::Value, cwd: &str) -> Result<Strin
     reject_relative_cwd_escape(raw_path, &path, cwd)?;
     let old_text = args["old_text"].as_str().context("missing old_text")?;
     let new_text = args["new_text"].as_str().context("missing new_text")?;
+    ensure_patchable_size(&path, MAX_PATCH_FILE_BYTES)?;
     let original =
         std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
     if !original.contains(old_text) {
@@ -140,4 +165,52 @@ pub(super) fn exec_fs_delete(args: &serde_json::Value, cwd: &str) -> Result<Stri
         std::fs::remove_file(&path).with_context(|| format!("rm {}", path.display()))?;
     }
     Ok(format!("Deleted {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_path(name: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "kaku_fs_patch_test_{}_{}",
+            std::process::id(),
+            name
+        ));
+        p
+    }
+
+    #[test]
+    fn ensure_patchable_size_rejects_oversized_file() {
+        let path = tmp_path("oversize");
+        std::fs::write(&path, b"0123456789").unwrap();
+        let err = ensure_patchable_size(&path, 4).unwrap_err();
+        assert!(err.to_string().contains("exceeds fs_patch limit"));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn ensure_patchable_size_accepts_file_within_limit() {
+        let path = tmp_path("withinlimit");
+        std::fs::write(&path, b"0123456789").unwrap();
+        assert_eq!(ensure_patchable_size(&path, 1024).unwrap(), 10);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn fs_patch_replaces_first_occurrence_for_normal_file() {
+        let path = tmp_path("patch_ok");
+        std::fs::write(&path, "hello world\nhello again\n").unwrap();
+        let args = serde_json::json!({
+            "path": path.to_string_lossy(),
+            "old_text": "hello",
+            "new_text": "hi",
+        });
+        let out = exec_fs_patch(&args, "/").unwrap();
+        assert!(out.contains("replaced 1 occurrence"));
+        let patched = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(patched, "hi world\nhello again\n");
+        std::fs::remove_file(&path).ok();
+    }
 }


### PR DESCRIPTION
Summary

fs_patch (the AI filesystem tool that edits a file by replacing old_text with new_text) loaded the entire target file into memory via std::fs::read_to_string with no size check. Its sibling fs_read already caps its read with .take(cap + 512), but fs_patch had no equivalent guard.

When an AI agent directs a patch at a large file inside the project root — a build artifact, log file, dataset, checked-in binary, or minified bundle — this allocates the file's full contents at once and risks an out-of-memory crash of the terminal. For binary files it is even worse: read_to_string buffers the whole file before the UTF-8 validation fails, so the allocation happens regardless. This is a self-inflicted DoS, not a privilege escalation (it requires the agent to target a large file on its own or via prompt injection).

Fix

Add an 8 MiB pre-read size guard in kaku-gui/src/ai_tools/fs.rs:

- MAX_PATCH_FILE_BYTES = 8 MiB — patching needs the whole file in memory (the replacement scans the full content), so unlike fs_read it cannot truncate; the strategy is to refuse oversized files instead.
- ensure_patchable_size(path, limit) — checks metadata().len() and bails before any read allocates the file. Extracted as a helper so the size logic is unit-testable with a small limit.
- Called right before read_to_string in exec_fs_patch.

The 8 MiB ceiling is generous for hand-written source (a 10k-line file is ~300 KB) and only blocks files that should never be edited via per-character replacement. For genuinely large files, the streaming path is shell_exec with sed/perl.