### PR TITLE
refactor(ai-tools): extract shared fs path-validation preamble

### DIFF
--- a/kaku-gui/src/ai_tools/fs.rs
+++ b/kaku-gui/src/ai_tools/fs.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use std::io::{BufRead, Read};
 use std::path::PathBuf;
 
-use super::paths::{reject_if_sensitive, reject_relative_cwd_escape, resolve};
+use super::paths::resolve_checked_arg;
 
 /// Maximum size of a file `fs_patch` will load into memory. Patching needs the
 /// whole file in memory (the replacement scans the full content), so unlike
@@ -31,10 +31,7 @@ fn ensure_patchable_size(path: &std::path::Path, limit: u64) -> Result<u64> {
 }
 
 pub(super) fn exec_fs_read(args: &serde_json::Value, cwd: &str, cap: usize) -> Result<String> {
-    let raw_path = args["path"].as_str().context("missing path")?;
-    let path = resolve(raw_path, cwd)?;
-    reject_if_sensitive(&path)?;
-    reject_relative_cwd_escape(raw_path, &path, cwd)?;
+    let path = resolve_checked_arg(args, cwd)?;
     let file = std::fs::File::open(&path).with_context(|| format!("read {}", path.display()))?;
 
     let start_line = args["start_line"].as_u64().map(|n| n as usize);
@@ -87,10 +84,7 @@ pub(super) fn exec_fs_read(args: &serde_json::Value, cwd: &str, cap: usize) -> R
 }
 
 pub(super) fn exec_fs_list(args: &serde_json::Value, cwd: &str) -> Result<String> {
-    let raw_path = args["path"].as_str().context("missing path")?;
-    let path = resolve(raw_path, cwd)?;
-    reject_if_sensitive(&path)?;
-    reject_relative_cwd_escape(raw_path, &path, cwd)?;
+    let path = resolve_checked_arg(args, cwd)?;
     let mut entries: Vec<String> = std::fs::read_dir(&path)
         .with_context(|| format!("list {}", path.display()))?
         .filter_map(|e| e.ok())
@@ -108,10 +102,7 @@ pub(super) fn exec_fs_list(args: &serde_json::Value, cwd: &str) -> Result<String
 }
 
 pub(super) fn exec_fs_write(args: &serde_json::Value, cwd: &str) -> Result<String> {
-    let raw_path = args["path"].as_str().context("missing path")?;
-    let path = resolve(raw_path, cwd)?;
-    reject_if_sensitive(&path)?;
-    reject_relative_cwd_escape(raw_path, &path, cwd)?;
+    let path = resolve_checked_arg(args, cwd)?;
     let content = args["content"].as_str().context("missing content")?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -125,10 +116,7 @@ pub(super) fn exec_fs_write(args: &serde_json::Value, cwd: &str) -> Result<Strin
 }
 
 pub(super) fn exec_fs_patch(args: &serde_json::Value, cwd: &str) -> Result<String> {
-    let raw_path = args["path"].as_str().context("missing path")?;
-    let path = resolve(raw_path, cwd)?;
-    reject_if_sensitive(&path)?;
-    reject_relative_cwd_escape(raw_path, &path, cwd)?;
+    let path = resolve_checked_arg(args, cwd)?;
     let old_text = args["old_text"].as_str().context("missing old_text")?;
     let new_text = args["new_text"].as_str().context("missing new_text")?;
     ensure_patchable_size(&path, MAX_PATCH_FILE_BYTES)?;
@@ -146,19 +134,13 @@ pub(super) fn exec_fs_patch(args: &serde_json::Value, cwd: &str) -> Result<Strin
 }
 
 pub(super) fn exec_fs_mkdir(args: &serde_json::Value, cwd: &str) -> Result<String> {
-    let raw_path = args["path"].as_str().context("missing path")?;
-    let path = resolve(raw_path, cwd)?;
-    reject_if_sensitive(&path)?;
-    reject_relative_cwd_escape(raw_path, &path, cwd)?;
+    let path = resolve_checked_arg(args, cwd)?;
     std::fs::create_dir_all(&path).with_context(|| format!("mkdir {}", path.display()))?;
     Ok(format!("Created {}", path.display()))
 }
 
 pub(super) fn exec_fs_delete(args: &serde_json::Value, cwd: &str) -> Result<String> {
-    let raw_path = args["path"].as_str().context("missing path")?;
-    let path: PathBuf = resolve(raw_path, cwd)?;
-    reject_if_sensitive(&path)?;
-    reject_relative_cwd_escape(raw_path, &path, cwd)?;
+    let path: PathBuf = resolve_checked_arg(args, cwd)?;
     if path.is_dir() {
         std::fs::remove_dir_all(&path).with_context(|| format!("rmdir {}", path.display()))?;
     } else {

--- a/kaku-gui/src/ai_tools/paths.rs
+++ b/kaku-gui/src/ai_tools/paths.rs
@@ -197,6 +197,20 @@ pub(crate) fn reject_relative_cwd_escape(raw_path: &str, resolved: &Path, cwd: &
     Ok(())
 }
 
+/// Resolve `args["path"]` against `cwd` and run both sandbox guards in order.
+///
+/// Single source of truth for the path-validation preamble shared by every
+/// `fs_*` tool: resolve `~`/relative paths, then `reject_if_sensitive` before
+/// `reject_relative_cwd_escape`. Collapsing the six identical copies here keeps
+/// the guard sequence from drifting between call sites.
+pub(crate) fn resolve_checked_arg(args: &serde_json::Value, cwd: &str) -> Result<PathBuf> {
+    let raw_path = args["path"].as_str().context("missing path")?;
+    let path = resolve(raw_path, cwd)?;
+    reject_if_sensitive(&path)?;
+    reject_relative_cwd_escape(raw_path, &path, cwd)?;
+    Ok(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,6 +231,30 @@ mod tests {
             resolve("/etc/passwd", "/tmp").unwrap(),
             PathBuf::from("/etc/passwd")
         );
+    }
+
+    #[test]
+    fn resolve_checked_arg_resolves_normal_path() {
+        let args = serde_json::json!({ "path": "/tmp" });
+        assert_eq!(
+            resolve_checked_arg(&args, "/tmp").unwrap(),
+            PathBuf::from("/tmp")
+        );
+    }
+
+    #[test]
+    fn resolve_checked_arg_rejects_sensitive_path() {
+        let home = std::env::var("HOME").expect("HOME not set");
+        let args = serde_json::json!({ "path": format!("{home}/.ssh/id_rsa") });
+        let err = resolve_checked_arg(&args, "/tmp").unwrap_err();
+        assert!(err.to_string().contains("protected") || err.to_string().contains("credential"));
+    }
+
+    #[test]
+    fn resolve_checked_arg_requires_path_arg() {
+        let args = serde_json::json!({});
+        let err = resolve_checked_arg(&args, "/tmp").unwrap_err();
+        assert!(err.to_string().contains("missing path"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The six `exec_fs_*` functions in `ai_tools/fs.rs` each duplicated the same four-line preamble — resolve the path arg, then `reject_if_sensitive` followed by `reject_relative_cwd_escape`. The guard order had already drifted from the `mod.rs` dispatcher, which is exactly the failure mode duplicated security checks invite.

## Change

- Add `paths::resolve_checked_arg(args, cwd) -> PathBuf` as the single source of truth for the fs path-validation preamble.
- Collapse the six `exec_fs_*` preambles to one call each (net -21 lines in fs.rs).
- Behavior is unchanged: both guards still run, in the same order.

## Tests

Three new tests in `ai_tools::paths::tests` cover the helper: normal-path resolve, sensitive-path rejection, and missing-`path`-arg error. All existing ai_tools tests pass (paths 22, fs incl. fs_patch), `cargo clippy -p kaku-gui --lib` clean, `cargo fmt` clean.