### PR TITLE
refactor(ai-tools): unify raw path validation for search tools

### DIFF
--- a/kaku-gui/src/ai_tools/mod.rs
+++ b/kaku-gui/src/ai_tools/mod.rs
@@ -19,7 +19,6 @@
 //! | `registry`    | ToolDef, all_tools, to_api_schema, budget_for       |
 
 use anyhow::{Context, Result};
-use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -113,36 +112,20 @@ pub fn execute(
             web::maybe_summarize_fetched(url, raw, config, raw_passthrough)
         }
         "project_summary" => {
-            let raw_path = args["path"].as_str();
-            let scan_path = raw_path
-                .map(|p| paths::resolve(p, cwd))
-                .transpose()?
-                .unwrap_or_else(|| PathBuf::from(cwd.as_str()));
-            if let Some(raw_path) = raw_path {
-                paths::reject_relative_cwd_escape(raw_path, &scan_path, cwd)?;
-            }
-            paths::reject_if_sensitive(&scan_path)?;
+            let raw_path = args["path"].as_str().unwrap_or(cwd);
+            let scan_path = paths::resolve_checked_path(raw_path, cwd)?;
             project::exec_project_summary(&scan_path)?
         }
         "file_tree" => {
-            let raw_path = args["path"].as_str();
-            let tree_path = raw_path
-                .map(|p| paths::resolve(p, cwd))
-                .transpose()?
-                .unwrap_or_else(|| PathBuf::from(cwd.as_str()));
-            if let Some(raw_path) = raw_path {
-                paths::reject_relative_cwd_escape(raw_path, &tree_path, cwd)?;
-            }
-            paths::reject_if_sensitive(&tree_path)?;
+            let raw_path = args["path"].as_str().unwrap_or(cwd);
+            let tree_path = paths::resolve_checked_path(raw_path, cwd)?;
             let depth = args["depth"].as_u64().unwrap_or(3).min(6) as usize;
             project::exec_file_tree(&tree_path, depth)?
         }
         "symbol_search" => {
             let query = args["query"].as_str().context("missing query")?;
             let search_path = args["path"].as_str().unwrap_or(cwd);
-            let resolved = paths::resolve(search_path, cwd)?;
-            paths::reject_relative_cwd_escape(search_path, &resolved, cwd)?;
-            paths::reject_if_sensitive(&resolved)?;
+            paths::resolve_checked_path(search_path, cwd)?;
             let kind = args["kind"].as_str().unwrap_or("all");
             let glob_filter = args["glob"].as_str();
             search::exec_symbol_search(query, kind, search_path, glob_filter, cwd, cancel)?
@@ -150,9 +133,7 @@ pub fn execute(
         "grep_search" => {
             let pattern = args["pattern"].as_str().context("missing pattern")?;
             let search_path = args["path"].as_str().unwrap_or(cwd);
-            let resolved = paths::resolve(search_path, cwd)?;
-            paths::reject_relative_cwd_escape(search_path, &resolved, cwd)?;
-            paths::reject_if_sensitive(&resolved)?;
+            paths::resolve_checked_path(search_path, cwd)?;
             let context_lines = args["context_lines"].as_u64().unwrap_or(2) as usize;
             let case_insensitive = args["case_insensitive"].as_bool().unwrap_or(false);
             let max_results = args["max_results"].as_u64().unwrap_or(100) as usize;

--- a/kaku-gui/src/ai_tools/paths.rs
+++ b/kaku-gui/src/ai_tools/paths.rs
@@ -197,18 +197,24 @@ pub(crate) fn reject_relative_cwd_escape(raw_path: &str, resolved: &Path, cwd: &
     Ok(())
 }
 
-/// Resolve `args["path"]` against `cwd` and run both sandbox guards in order.
+/// Resolve a raw tool path against `cwd` and run both sandbox guards in order.
 ///
 /// Single source of truth for the path-validation preamble shared by every
-/// `fs_*` tool: resolve `~`/relative paths, then `reject_if_sensitive` before
-/// `reject_relative_cwd_escape`. Collapsing the six identical copies here keeps
+/// fs / search / tree tool: resolve `~`/relative paths, then
+/// `reject_if_sensitive` before `reject_relative_cwd_escape`. Collapsing
+/// identical copies here keeps
 /// the guard sequence from drifting between call sites.
-pub(crate) fn resolve_checked_arg(args: &serde_json::Value, cwd: &str) -> Result<PathBuf> {
-    let raw_path = args["path"].as_str().context("missing path")?;
+pub(crate) fn resolve_checked_path(raw_path: &str, cwd: &str) -> Result<PathBuf> {
     let path = resolve(raw_path, cwd)?;
     reject_if_sensitive(&path)?;
     reject_relative_cwd_escape(raw_path, &path, cwd)?;
     Ok(path)
+}
+
+/// Resolve `args["path"]` against `cwd` and run both sandbox guards in order.
+pub(crate) fn resolve_checked_arg(args: &serde_json::Value, cwd: &str) -> Result<PathBuf> {
+    let raw_path = args["path"].as_str().context("missing path")?;
+    resolve_checked_path(raw_path, cwd)
 }
 
 #[cfg(test)]
@@ -238,6 +244,14 @@ mod tests {
         let args = serde_json::json!({ "path": "/tmp" });
         assert_eq!(
             resolve_checked_arg(&args, "/tmp").unwrap(),
+            PathBuf::from("/tmp")
+        );
+    }
+
+    #[test]
+    fn resolve_checked_path_resolves_normal_path() {
+        assert_eq!(
+            resolve_checked_path("/tmp", "/tmp").unwrap(),
             PathBuf::from("/tmp")
         );
     }


### PR DESCRIPTION
  Description

  ## Summary

  - Add `resolve_checked_path` for raw-path AI tool validation.
  - Reuse the shared path-validation preamble in `project_summary`, `file_tree`, `symbol_search`, and `grep_search`.
  - Keep the existing security boundary unchanged: sensitive-path checks and relative cwd-escape checks still both run.

  ## Verification

  - `cargo fmt --check`
  - `cargo test -p kaku-gui ai_tools:: --lib`
  - `cargo check -p kaku-gui`