### PR TITLE
feat(tabbar): show foreground process in tab titles

### DIFF
--- a/assets/macos/Kaku.app/Contents/Resources/kaku.lua
+++ b/assets/macos/Kaku.app/Contents/Resources/kaku.lua
@@ -844,7 +844,7 @@ local function is_shell_foreground(pane)
   end
 
   -- Normalize full executable paths (e.g., /bin/zsh) and login shell names (e.g., -zsh).
-  local name = basename(proc:lower()):gsub("^%-", "")
+  local name = (basename(proc:lower()) or proc:lower()):gsub("^%-", "")
   local shells = { zsh = true, bash = true, fish = true, sh = true, dash = true, ksh = true, tcsh = true, csh = true }
   return shells[name] == true
 end
@@ -2661,6 +2661,47 @@ local function pane_foreground_process_info(pane)
   return info
 end
 
+function kaku_foreground_process_title(pane)
+  if not pane then
+    return nil
+  end
+
+  local function normalized_process_basename(proc)
+    if type(proc) ~= "string" or proc == "" then
+      return ""
+    end
+    return (basename(proc:lower()) or proc:lower()):gsub("^%-", "")
+  end
+
+  local function is_shell_process_name(proc)
+    local name = normalized_process_basename(proc)
+    local shells = { zsh = true, bash = true, fish = true, sh = true, dash = true, ksh = true, tcsh = true, csh = true }
+    return shells[name] == true
+  end
+
+  local info = pane_foreground_process_info(pane)
+  if info and type(info.argv) == "table" and #info.argv > 0 then
+    local command = normalized_process_basename(tostring(info.argv[1] or ""))
+    if command ~= "" and command ~= "ssh" and not is_shell_process_name(command) then
+      if (command == "npm" or command == "pnpm" or command == "yarn" or command == "bun") and #info.argv >= 2 then
+        local parts = { command }
+        for i = 2, math.min(#info.argv, 3) do
+          parts[#parts + 1] = tostring(info.argv[i])
+        end
+        return table.concat(parts, " ")
+      end
+      return command
+    end
+  end
+
+  local proc_name = pane_foreground_process_name(pane)
+  local command = normalized_process_basename(proc_name)
+  if command == "" or command == "ssh" or is_shell_process_name(command) then
+    return nil
+  end
+  return command
+end
+
 local function pane_cwd_value(pane)
   if not pane then
     return nil
@@ -3227,6 +3268,12 @@ local function tab_display_title(tab, effective_config)
   local active_pane = tab and tab.active_pane or nil
   local text = tab and tab.tab_title or ''
 
+  if text == '' and active_pane then
+    text = resolve_remote_target_from_pane(active_pane) or ''
+  end
+  if text == '' and active_pane then
+    text = kaku_foreground_process_title(active_pane) or ''
+  end
   if text == '' and tab then
     local parent, current = tab_path_parts(tab)
     local basename_only = effective_config and effective_config.tab_title_show_basename_only
@@ -3236,9 +3283,6 @@ local function tab_display_title(tab, effective_config)
     end
   end
 
-  if text == '' and active_pane then
-    text = resolve_remote_target_from_pane(active_pane) or ''
-  end
   if text == '' and active_pane then
     text = active_pane.title or ''
   end
@@ -3312,8 +3356,13 @@ wezterm.on('format-tab-title', function(tab, tabs, panes, effective_config, hove
       if not basename_only and parent ~= '' and current ~= '' then
         seg_text = parent .. '/' .. current
       end
+      local remote_target = resolve_remote_target_from_pane(p)
+      local process_title = kaku_foreground_process_title(p)
+      if process_title then
+        seg_text = process_title
+      end
       if seg_text == '' then
-        seg_text = resolve_remote_target_from_pane(p) or p.title or '?'
+        seg_text = remote_target or p.title or '?'
       end
       local idx = seg_index[seg_text]
       if idx then

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,7 +187,10 @@ config.split_pane_inherit_working_directory = true -- new splits
 
 **Tab bar**
 
-Hidden when only one tab is open. Change position or show only the current directory name:
+Hidden when only one tab is open. Kaku shows stateful foreground processes
+such as `claude`, `vim`, `lazygit`, or `npm run dev` in tab titles; idle shell
+tabs fall back to the current directory. Change position or show only the
+current directory name:
 
 ```lua
 config.tab_bar_at_bottom = false        -- move to top

--- a/kaku-gui/src/tabbar.rs
+++ b/kaku-gui/src/tabbar.rs
@@ -272,6 +272,12 @@ fn tab_multi_pane_title(tab_id: TabId) -> Option<String> {
         let Some(real_pane) = mux.get_pane(pos.pane.pane_id()) else {
             continue;
         };
+        if let Some(process_title) = foreground_process_title(&*real_pane) {
+            if !parts.iter().any(|p| p == &process_title) {
+                parts.push(process_title);
+            }
+            continue;
+        }
         let Some(cwd) = real_pane.get_current_working_dir(CachePolicy::AllowStale) else {
             continue;
         };
@@ -327,6 +333,8 @@ fn compute_tab_title_from_precomputed(
                     tab.tab_title.clone()
                 } else if let Some(multi) = tab_multi_pane_title(tab.tab_id) {
                     multi
+                } else if let Some(process_title) = foreground_process_title_for_pane_info(pane) {
+                    process_title
                 } else if let Some(path_title) = pane_cwd_title(pane) {
                     path_title
                 } else if let Some(ssh_host) = ssh_destination_for_pane(pane) {
@@ -384,11 +392,14 @@ pub fn compute_tab_plain_title(tab: &TabInformation) -> String {
             }
         }
 
-        if let Some(title) = pane_cwd_title(pane) {
-            return title;
-        }
         if let Some(ssh_host) = ssh_destination_for_pane(pane) {
             return ssh_host;
+        }
+        if let Some(process_title) = foreground_process_title_for_pane_info(pane) {
+            return process_title;
+        }
+        if let Some(title) = pane_cwd_title(pane) {
+            return title;
         }
         return pane.title.clone();
     }
@@ -572,6 +583,56 @@ fn command_basename(command: &str) -> &str {
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or(command)
+}
+
+fn normalized_process_basename(command: &str) -> String {
+    command_basename(command)
+        .trim_start_matches('-')
+        .to_ascii_lowercase()
+}
+
+fn is_shell_process_name(command: &str) -> bool {
+    matches!(
+        normalized_process_basename(command).as_str(),
+        "zsh" | "bash" | "fish" | "sh" | "dash" | "ksh" | "tcsh" | "csh"
+    )
+}
+
+fn process_title_from_argv(argv: &[String]) -> Option<String> {
+    let command = argv.first().map(|arg| normalized_process_basename(arg))?;
+    if command.is_empty() || command == "ssh" || is_shell_process_name(&command) {
+        return None;
+    }
+
+    if matches!(command.as_str(), "npm" | "pnpm" | "yarn" | "bun") && argv.len() >= 2 {
+        let mut parts = vec![command];
+        parts.extend(argv.iter().skip(1).take(2).cloned());
+        return Some(parts.join(" "));
+    }
+
+    Some(command)
+}
+
+fn foreground_process_title(pane: &dyn mux::pane::Pane) -> Option<String> {
+    if let Some(info) = pane.get_foreground_process_info(CachePolicy::AllowStale) {
+        if let Some(title) = process_title_from_argv(&info.argv) {
+            return Some(title);
+        }
+    }
+
+    let proc_name = pane.get_foreground_process_name(CachePolicy::AllowStale)?;
+    let command = normalized_process_basename(&proc_name);
+    if command.is_empty() || command == "ssh" || is_shell_process_name(&command) {
+        None
+    } else {
+        Some(command)
+    }
+}
+
+fn foreground_process_title_for_pane_info(pane: &PaneInformation) -> Option<String> {
+    let mux = Mux::try_get()?;
+    let real_pane = mux.get_pane(pane.pane_id)?;
+    foreground_process_title(&*real_pane)
 }
 
 fn normalize_ssh_target(target: &str) -> Option<String> {
@@ -1306,6 +1367,38 @@ mod test {
     #[test]
     fn ignore_non_ssh_command() {
         assert!(ssh_target_from_command("ls -la").is_none());
+    }
+
+    #[test]
+    fn process_title_ignores_shells_and_ssh() {
+        assert_eq!(process_title_from_argv(&["/bin/zsh".to_string()]), None);
+        assert_eq!(process_title_from_argv(&["-bash".to_string()]), None);
+        assert_eq!(
+            process_title_from_argv(&["ssh".to_string(), "host".to_string()]),
+            None
+        );
+    }
+
+    #[test]
+    fn process_title_keeps_package_manager_task() {
+        assert_eq!(
+            process_title_from_argv(&[
+                "/opt/homebrew/bin/npm".to_string(),
+                "run".to_string(),
+                "dev".to_string(),
+                "--".to_string(),
+            ])
+            .as_deref(),
+            Some("npm run dev")
+        );
+    }
+
+    #[test]
+    fn process_title_uses_command_basename() {
+        assert_eq!(
+            process_title_from_argv(&["/usr/local/bin/claude".to_string()]).as_deref(),
+            Some("claude")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  Implements #475.

  - Show stateful foreground processes in tab titles, such as `claude`, `vim`, `lazygit`, and `npm run dev`.
  - Keep idle shell tabs focused on the current directory instead of showing `zsh`, `bash`, or `fish`.
  - Preserve SSH tab behavior by continuing to show the remote target.
  - Apply the same behavior to both the bundled Lua tab formatter and the Rust fallback path.