### PR TITLE
fix: clear mouse button state when modal consumes Release event

### DIFF
--- a/kaku-gui/src/termwindow/mouseevent.rs
+++ b/kaku-gui/src/termwindow/mouseevent.rs
@@ -570,6 +570,10 @@ impl super::TermWindow {
         // Keep modal focus exclusive: forward all mouse events to it and stop
         // routing into pane/tab UI while active.
         if let Some(modal) = self.get_modal() {
+            if let WMEK::Release(press) = &event.kind {
+                self.finish_mouse_release(*press);
+            }
+
             let (kind, button) = wmek_to_tmek_and_button(&event);
             let modal_event = wezterm_term::MouseEvent {
                 kind,


### PR DESCRIPTION
# Summary

When tab rename is opened via double-click on the tab bar and then cancelled, subsequent mouse movement creates a phantom text selection that follows the cursor.  The selection extends with each mouse move as if the left button is held down.

# Changes

- **mouseevent.rs**: Before forwarding a mouse event to the active modal, call `finish_mouse_release` for `WMEK::Release` events.
  Previously, the modal consumed the Release without updating `current_mouse_buttons`, leaving a stale `MousePress::Left` that turned plain mouse moves into phantom drag operations.

# Related Issues

Closed #487 