### PR TITLE
fix(gui): make Cmd+, open single settings window

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -339,7 +339,7 @@ wezterm.on('augment-command-palette', function(window, pane)
   -- so directories containing spaces or non-ASCII characters work too.
   local host = cwd_obj.host
   if cwd_obj.scheme ~= 'file'
-      or (host and host ~= '' and host ~= 'localhost' and host ~= wezterm.hostname()) then
+      or (host and host ~= '' and host ~= 'localhost' and host ~= wezterm.hostname():lower()) then
     return {}
   end
   local cwd = cwd_obj.file_path

--- a/kaku-gui/src/frontend.rs
+++ b/kaku-gui/src/frontend.rs
@@ -13,11 +13,11 @@ use mux::window::WindowId as MuxWindowId;
 use mux::{Mux, MuxNotification};
 use promise::{Future, Promise};
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use wezterm_term::{Alert, ClipboardSelection};
 use wezterm_toast_notification::*;
 
@@ -135,16 +135,75 @@ pub(crate) fn kaku_cli_program_for_spawn() -> String {
     }
 }
 
+struct SingletonState {
+    window_id: MuxWindowId,
+    pending: bool,
+}
+
+static SINGLETON_WINDOWS: LazyLock<Mutex<HashMap<&'static str, SingletonState>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Open or focus a singleton window identified by `namespace`.
+/// If a window for the given namespace already exists, focus it.
+/// Otherwise, run `handler` to create one and track it by namespace.
+fn ensure_singleton_window<F, Fut>(namespace: &'static str, handler: F)
+where
+    F: FnOnce() -> Fut + 'static,
+    Fut: std::future::Future<Output = anyhow::Result<MuxWindowId>> + 'static,
+{
+    // Atomic check-and-mark: if window exists, focus and return;
+    // otherwise mark as pending to prevent duplicate spawns.
+    {
+        let mut guard = SINGLETON_WINDOWS.lock().unwrap();
+        if let Some(state) = guard.get(namespace) {
+            if state.pending {
+                return;
+            }
+            if Mux::get().get_window(state.window_id).is_some() {
+                if let Some(fe) = try_front_end() {
+                    if let Some(gw) = fe.gui_window_for_mux_window(state.window_id) {
+                        gw.window.focus();
+                        return;
+                    }
+                }
+            }
+        }
+        guard.insert(
+            namespace,
+            SingletonState {
+                window_id: 0,
+                pending: true,
+            },
+        );
+    }
+
+    promise::spawn::spawn(async move {
+        match handler().await {
+            Ok(window_id) => {
+                let mut guard = SINGLETON_WINDOWS.lock().unwrap();
+                if let Some(state) = guard.get_mut(namespace) {
+                    state.window_id = window_id;
+                    state.pending = false;
+                }
+            }
+            Err(err) => {
+                log::error!("singleton window '{namespace}' error: {:#}", err);
+                SINGLETON_WINDOWS.lock().unwrap().remove(namespace);
+            }
+        }
+    })
+    .detach();
+}
+
 pub fn open_kaku_config() {
     let kaku_bin = kaku_cli_program_for_spawn();
-
-    promise::spawn::spawn_into_main_thread(async move {
+    ensure_singleton_window("kaku-config", async move || {
         let config = fast_config_snapshot();
         let dpi = config.dpi.unwrap_or_else(|| ::window::default_dpi());
         let size = config.initial_size(dpi as u32, None);
         let term_config = Arc::new(config::TermConfig::with_config(config));
-        crate::spawn::spawn_command_impl(
-            &SpawnCommand {
+        crate::spawn::spawn_command_internal(
+            SpawnCommand {
                 domain: SpawnTabDomain::DomainName("local".to_string()),
                 args: Some(vec![kaku_bin, "config".to_string()]),
                 ..Default::default()
@@ -155,9 +214,9 @@ pub fn open_kaku_config() {
             size,
             None,
             term_config,
-        );
-    })
-    .detach();
+        )
+        .await
+    });
 }
 
 pub fn run_kaku_update_from_menu() {

--- a/kaku-gui/src/spawn.rs
+++ b/kaku-gui/src/spawn.rs
@@ -42,7 +42,7 @@ pub async fn spawn_command_internal(
     size: TerminalSize,
     src_window_id: Option<MuxWindowId>,
     term_config: Arc<TermConfig>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<MuxWindowId> {
     let mux = Mux::get();
     let activity = Activity::new();
 
@@ -99,7 +99,7 @@ pub async fn spawn_command_internal(
 
     let workspace = mux.active_workspace().clone();
 
-    match spawn_where {
+    let window_id = match spawn_where {
         SpawnWhere::SplitPane(direction) => {
             let src_window_id = match src_window_id {
                 Some(id) => id,
@@ -133,6 +133,7 @@ pub async fn spawn_command_internal(
             } else {
                 bail!("there is no active tab while splitting pane!?");
             }
+            src_window_id
         }
         _ => {
             let (_tab, pane, window_id) = mux
@@ -159,10 +160,11 @@ pub async fn spawn_command_internal(
             if Some(window_id) == src_window_id {
                 pane.set_config(term_config);
             }
+            window_id
         }
     };
 
     drop(activity);
 
-    Ok(())
+    Ok(window_id)
 }


### PR DESCRIPTION
## Summary

- Cmd+, (Open Settings) currently spawns a new settings window every time, piling up duplicates on rapid presses. This fix makes Settings a singleton: if one already exists, Cmd+, focuses it instead of creating another.

- Also fixes a Lua code example in docs where `cwd_obj.host` always get lowercase hostname but `wezterm.hostname` get default hostname.

- Align rename modal text to stay adjacent to the tab item regardless of tab bar position (top/bottom).

## Changes

- **`spawn_command_internal`** returns `anyhow::Result<MuxWindowId>` instead of `()`. Callers that don't need the ID (`spawn_command_impl`, termwindow handler) discard it with the existing `if let Err` pattern — no behavioral change.

- **`ensure_singleton_window(namespace, handler)`** — generic helper in `frontend.rs`. On first call per namespace it runs `handler`, stores the returned `MuxWindowId`. Subsequent calls check if that window is still alive (`Mux::get_window()`) and focus it via `try_front_end → gui_window_for_mux_window → focus`. A `pending` flag guards against duplicate spawns while the first is still in flight.

- **`open_kaku_config`** delegates to `ensure_singleton_window("kaku-config", async || { spawn_command_internal(...).await })`.

- **`docs/configuration.md`** — add `:lower()` to `wezterm.hostname()` comparison in Lua example (`Url::parse` lowercases host per RFC 3986, so the comparison target must also be lowercase to match).