### PR TITLE
feat(gui): close tabs with Backspace in Tab Navigator

### DIFF
--- a/kaku-gui/src/overlay/launcher.rs
+++ b/kaku-gui/src/overlay/launcher.rs
@@ -556,13 +556,13 @@ impl LauncherState {
     }
 
     fn close_tab_action(&self) -> Option<LauncherAction> {
-        match self.filtered_entries.get(self.active_idx) {
-            Some(Entry {
-                action: LauncherAction::ActivatePane { tab_id, .. },
-                ..
-            }) => Some(LauncherAction::CloseNavigatorTab(*tab_id)),
-            _ => None,
-        }
+        backspace_tab_close_action(
+            self.allow_tab_close,
+            self.filtering,
+            self.filtered_entries
+                .get(self.active_idx)
+                .map(|entry| &entry.action),
+        )
     }
 
     fn move_up(&mut self) {
@@ -673,12 +673,10 @@ impl LauncherState {
                     key: KeyCode::Backspace,
                     ..
                 }) => {
+                    if let Some(action) = self.close_tab_action() {
+                        return Ok(Some(action));
+                    }
                     if !self.filtering {
-                        if self.allow_tab_close {
-                            if let Some(action) = self.close_tab_action() {
-                                return Ok(Some(action));
-                            }
-                        }
                         self.selection.pop();
                     } else {
                         if self.filter_term.pop().is_none() && !self.always_fuzzy {
@@ -766,6 +764,23 @@ impl LauncherState {
     }
 }
 
+fn backspace_tab_close_action(
+    allow_tab_close: bool,
+    filtering: bool,
+    action: Option<&LauncherAction>,
+) -> Option<LauncherAction> {
+    if !allow_tab_close || filtering {
+        return None;
+    }
+
+    match action {
+        Some(LauncherAction::ActivatePane { tab_id, .. }) => {
+            Some(LauncherAction::CloseNavigatorTab(*tab_id))
+        }
+        _ => None,
+    }
+}
+
 fn launcher_tab_action(tab: &LauncherTabEntry) -> LauncherAction {
     LauncherAction::ActivatePane {
         pane_id: tab.pane_id,
@@ -810,6 +825,13 @@ pub fn launcher(
 mod tests {
     use super::*;
 
+    fn pane_action(tab_id: TabId) -> LauncherAction {
+        LauncherAction::ActivatePane {
+            pane_id: 42.into(),
+            tab_id,
+        }
+    }
+
     #[test]
     fn pane_entries_keep_the_stable_pane_id() {
         let entry = LauncherTabEntry {
@@ -824,6 +846,33 @@ mod tests {
                 pane_id: 42.into(),
                 tab_id: TabId::new(7),
             }
+        );
+    }
+
+    #[test]
+    fn backspace_closes_the_selected_tab_in_the_navigator() {
+        let action = pane_action(TabId::new(7));
+
+        assert_eq!(
+            backspace_tab_close_action(true, false, Some(&action)),
+            Some(LauncherAction::CloseNavigatorTab(TabId::new(7)))
+        );
+    }
+
+    #[test]
+    fn backspace_does_not_close_a_tab_while_filtering() {
+        let action = pane_action(TabId::new(7));
+
+        assert_eq!(backspace_tab_close_action(true, true, Some(&action)), None);
+    }
+
+    #[test]
+    fn backspace_does_not_close_a_tab_in_a_custom_launcher() {
+        let action = pane_action(TabId::new(7));
+
+        assert_eq!(
+            backspace_tab_close_action(false, false, Some(&action)),
+            None
         );
     }
 }

--- a/kaku-gui/src/overlay/launcher.rs
+++ b/kaku-gui/src/overlay/launcher.rs
@@ -16,6 +16,7 @@ use config::keyassignment::{
 };
 use mux::domain::{DomainId, DomainState};
 use mux::pane::PaneId;
+use mux::tab::TabId;
 use mux::termwiztermtab::TermWizTerminal;
 use mux::Mux;
 use rayon::prelude::*;
@@ -38,12 +39,14 @@ struct Entry {
 pub struct LauncherTabEntry {
     pub title: String,
     pub pane_id: PaneId,
+    pub tab_id: TabId,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum LauncherAction {
     Assignment(KeyAssignment),
-    ActivatePane(PaneId),
+    ActivatePane { pane_id: PaneId, tab_id: TabId },
+    CloseNavigatorTab(TabId),
 }
 
 impl From<KeyAssignment> for LauncherAction {
@@ -171,6 +174,7 @@ struct LauncherState {
     alphabet: String,
     selection: String,
     always_fuzzy: bool,
+    allow_tab_close: bool,
     parent_state: Option<ParentLauncherState>,
 }
 
@@ -551,6 +555,16 @@ impl LauncherState {
         Some(action)
     }
 
+    fn close_tab_action(&self) -> Option<LauncherAction> {
+        match self.filtered_entries.get(self.active_idx) {
+            Some(Entry {
+                action: LauncherAction::ActivatePane { tab_id, .. },
+                ..
+            }) => Some(LauncherAction::CloseNavigatorTab(*tab_id)),
+            _ => None,
+        }
+    }
+
     fn move_up(&mut self) {
         self.active_idx = self.active_idx.saturating_sub(1);
         if self.active_idx < self.top_row {
@@ -660,6 +674,11 @@ impl LauncherState {
                     ..
                 }) => {
                     if !self.filtering {
+                        if self.allow_tab_close {
+                            if let Some(action) = self.close_tab_action() {
+                                return Ok(Some(action));
+                            }
+                        }
                         self.selection.pop();
                     } else {
                         if self.filter_term.pop().is_none() && !self.always_fuzzy {
@@ -748,13 +767,17 @@ impl LauncherState {
 }
 
 fn launcher_tab_action(tab: &LauncherTabEntry) -> LauncherAction {
-    LauncherAction::ActivatePane(tab.pane_id)
+    LauncherAction::ActivatePane {
+        pane_id: tab.pane_id,
+        tab_id: tab.tab_id,
+    }
 }
 
 pub fn launcher(
     args: LauncherArgs,
     mut term: TermWizTerminal,
     initial_choice_idx: usize,
+    allow_tab_close: bool,
 ) -> anyhow::Result<Option<LauncherAction>> {
     let filtering = args.flags.contains(LauncherFlags::FUZZY);
     let mut state = LauncherState {
@@ -771,6 +794,7 @@ pub fn launcher(
         selection: String::new(),
         alphabet: args.alphabet.clone(),
         always_fuzzy: filtering,
+        allow_tab_close,
         parent_state: None,
     };
 
@@ -791,11 +815,15 @@ mod tests {
         let entry = LauncherTabEntry {
             title: "  |- src/main.rs".to_string(),
             pane_id: 42.into(),
+            tab_id: TabId::new(7),
         };
 
         assert_eq!(
             launcher_tab_action(&entry),
-            LauncherAction::ActivatePane(42.into())
+            LauncherAction::ActivatePane {
+                pane_id: 42.into(),
+                tab_id: TabId::new(7),
+            }
         );
     }
 }

--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -4051,15 +4051,29 @@ impl TermWindow {
             Some(mux_window) => mux_window.get_active_idx(),
             None => return,
         };
+        self.show_tab_navigator_at(active_tab_idx);
+    }
+
+    fn show_tab_navigator_at(&mut self, initial_choice_idx: usize) {
+        let mux = Mux::get();
+        let initial_choice_idx = match mux.get_window(self.mux_window_id) {
+            Some(mux_window) if !mux_window.is_empty() => {
+                initial_choice_idx.min(mux_window.len() - 1)
+            }
+            _ => return,
+        };
         let title = "Tab Navigator".to_string();
         let args = LauncherActionArgs {
             title: Some(title),
             flags: LauncherFlags::TABS,
-            help_text: None,
+            help_text: Some(
+                "Select an item and press Enter=launch  Backspace=close  Esc=cancel  /=filter"
+                    .to_string(),
+            ),
             fuzzy_help_text: None,
             alphabet: None,
         };
-        self.show_launcher_impl(args, active_tab_idx);
+        self.show_launcher_impl(args, initial_choice_idx, true);
     }
 
     fn show_launcher(&mut self) {
@@ -4073,10 +4087,15 @@ impl TermWindow {
             fuzzy_help_text: None,
             alphabet: None,
         };
-        self.show_launcher_impl(args, 0);
+        self.show_launcher_impl(args, 0, false);
     }
 
-    fn show_launcher_impl(&mut self, args: LauncherActionArgs, initial_choice_idx: usize) {
+    fn show_launcher_impl(
+        &mut self,
+        args: LauncherActionArgs,
+        initial_choice_idx: usize,
+        is_tab_navigator: bool,
+    ) {
         let window = self.window.as_ref().unwrap().clone();
 
         let mux = Mux::get();
@@ -4085,9 +4104,18 @@ impl TermWindow {
             None => return,
         };
 
-        let pane = match self.get_active_pane_or_overlay() {
-            Some(pane) => pane,
-            None => return,
+        // A rebuilt Navigator can overlap the prior overlay's shutdown, so bind
+        // its actions to the real pane rather than the overlay being replaced.
+        let pane = if is_tab_navigator {
+            match tab.get_active_pane() {
+                Some(pane) => pane,
+                None => return,
+            }
+        } else {
+            match self.get_active_pane_or_overlay() {
+                Some(pane) => pane,
+                None => return,
+            }
         };
 
         let domain_id_of_current_pane = tab
@@ -4129,6 +4157,7 @@ impl TermWindow {
                     entries.push(LauncherTabEntry {
                         title: crate::tabbar::compute_tab_plain_title(tab),
                         pane_id,
+                        tab_id: tab.tab_id,
                     });
                     continue;
                 }
@@ -4155,6 +4184,7 @@ impl TermWindow {
                             format!("  |- {title}")
                         },
                         pane_id: pane.pane.pane_id(),
+                        tab_id: tab.tab_id,
                     });
                 }
             }
@@ -4182,7 +4212,12 @@ impl TermWindow {
                     let window = window.clone();
                     let (overlay, future) =
                         start_overlay(term_window, &tab, move |_tab_id, term| {
-                            launcher(args, term, launcher_initial_choice_idx)
+                            launcher(
+                                args,
+                                term,
+                                launcher_initial_choice_idx,
+                                is_tab_navigator,
+                            )
                         });
 
                     term_window.assign_overlay(tab_id, overlay);
@@ -4195,7 +4230,10 @@ impl TermWindow {
                                     tx: None,
                                 });
                             }
-                            Ok(Some(LauncherAction::ActivatePane(target_pane_id))) => {
+                            Ok(Some(LauncherAction::ActivatePane {
+                                pane_id: target_pane_id,
+                                ..
+                            })) => {
                                 window.notify(TermWindowNotif::Apply(Box::new(
                                     move |term_window| {
                                         if let Err(err) = Mux::get()
@@ -4206,6 +4244,13 @@ impl TermWindow {
                                             );
                                         }
                                         term_window.update_title_post_status();
+                                    },
+                                )));
+                            }
+                            Ok(Some(LauncherAction::CloseNavigatorTab(tab_id))) => {
+                                window.notify(TermWindowNotif::Apply(Box::new(
+                                    move |term_window| {
+                                        term_window.close_tab_from_navigator(tab_id);
                                     },
                                 )));
                             }
@@ -4609,7 +4654,7 @@ impl TermWindow {
                     fuzzy_help_text: args.fuzzy_help_text.clone(),
                     alphabet: args.alphabet.clone(),
                 };
-                self.show_launcher_impl(args, 0);
+                self.show_launcher_impl(args, 0, false);
             }
             HideApplication => {
                 let con = Connection::get().expect("call on gui thread");
@@ -5537,6 +5582,105 @@ impl TermWindow {
         }
     }
 
+    fn close_tab_from_navigator(&mut self, tab_id: TabId) {
+        let mux = Mux::get();
+        let target = {
+            let mux_window = match mux.get_window(self.mux_window_id) {
+                Some(window) => window,
+                None => return,
+            };
+            if mux_window.len() <= 1 {
+                return;
+            }
+            mux_window.idx_by_id(tab_id).and_then(|tab_idx| {
+                mux_window
+                    .get_by_idx(tab_idx)
+                    .cloned()
+                    .map(|tab| (tab_idx, tab))
+            })
+        };
+
+        let Some((tab_idx, tab)) = target else {
+            self.show_tab_navigator();
+            return;
+        };
+
+        let should_confirm = self
+            .config
+            .tab_close_confirmation
+            .should_prompt(true, || tab.can_close_without_prompting(CloseReason::Tab));
+        if should_confirm {
+            let Some(host_tab) = mux.get_active_tab_for_window(self.mux_window_id) else {
+                return;
+            };
+            let host_tab_id = host_tab.tab_id();
+            if let Some(window) = self.window.clone() {
+                let notify_window = window.clone();
+                let (overlay, future) = start_overlay(self, &host_tab, move |_tab_id, mut term| {
+                    crate::overlay::confirm::run_confirmation(
+                        "Close this tab?\nAll panes in this tab will be terminated.",
+                        &mut term,
+                    )
+                });
+                self.assign_overlay(host_tab_id, overlay);
+                promise::spawn::spawn(async move {
+                    let confirmed = match future.await {
+                        Ok(confirmed) => confirmed,
+                        Err(err) => {
+                            log::error!("tab navigator close confirmation failed: {err:#}");
+                            false
+                        }
+                    };
+                    notify_window.notify(TermWindowNotif::Apply(Box::new(move |term_window| {
+                        term_window.finish_navigator_tab_close(tab_id, confirmed);
+                    })));
+                })
+                .detach();
+            }
+        } else {
+            self.record_closed_tab_cwd(&tab);
+            if mux.remove_tab(tab_id).is_some() {
+                self.update_title();
+                self.show_tab_navigator_at(tab_idx);
+            } else {
+                self.show_tab_navigator();
+            }
+        }
+    }
+
+    fn finish_navigator_tab_close(&mut self, tab_id: TabId, confirmed: bool) {
+        let mux = Mux::get();
+        let (tab_count, active_idx, target) = {
+            let mux_window = match mux.get_window(self.mux_window_id) {
+                Some(window) => window,
+                None => return,
+            };
+            let target = mux_window.idx_by_id(tab_id).and_then(|tab_idx| {
+                mux_window
+                    .get_by_idx(tab_idx)
+                    .cloned()
+                    .map(|tab| (tab_idx, tab))
+            });
+            (mux_window.len(), mux_window.get_active_idx(), target)
+        };
+
+        let initial_choice_idx = match target {
+            Some((tab_idx, tab)) if confirmed && tab_count > 1 => {
+                self.record_closed_tab_cwd(&tab);
+                if mux.remove_tab(tab_id).is_some() {
+                    self.update_title();
+                    tab_idx
+                } else {
+                    active_idx
+                }
+            }
+            Some((tab_idx, _)) => tab_idx,
+            None => active_idx,
+        };
+
+        self.show_tab_navigator_at(initial_choice_idx);
+    }
+
     fn close_specific_tab(&mut self, tab_idx: usize, confirm: bool) {
         let mux = Mux::get();
         let mux_window_id = self.mux_window_id;
@@ -5604,17 +5748,21 @@ impl TermWindow {
             }
         } else {
             // No confirmation needed: record cwd and close immediately.
-            if let Some(pane) = tab.get_active_pane() {
-                if let Some(cwd) = pane
-                    .get_current_working_dir(mux::pane::CachePolicy::AllowStale)
-                    .and_then(|url| url.to_file_path().ok())
-                {
-                    if cwd.is_absolute() {
-                        self.push_closed_tab_cwd(cwd);
-                    }
+            self.record_closed_tab_cwd(&tab);
+            mux.remove_tab(tab_id);
+        }
+    }
+
+    fn record_closed_tab_cwd(&mut self, tab: &Arc<Tab>) {
+        if let Some(pane) = tab.get_active_pane() {
+            if let Some(cwd) = pane
+                .get_current_working_dir(mux::pane::CachePolicy::AllowStale)
+                .and_then(|url| url.to_file_path().ok())
+            {
+                if cwd.is_absolute() {
+                    self.push_closed_tab_cwd(cwd);
                 }
             }
-            mux.remove_tab(tab_id);
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `Backspace` support for closing the selected tab from the built-in Tab Navigator.
- Keep the Navigator open after closing a tab.
- When only one tab remains, `Backspace` exits the Navigator instead of closing the final tab or window.
- Preserve close confirmations for tabs with running processes.
- Keep custom launchers unchanged.

## Motivation

This interaction was inspired by Claude Code's Agent View.

On my Mac, the existing `Cmd+Shift+W` shortcut for closing a tab conflicts with another system or application shortcut, so I cannot use it reliably.

Since the Tab Navigator already provides a keyboard-driven way to find and switch tabs, supporting `Backspace` there provides a convenient alternative for closing tabs without changing or replacing the existing shortcut.

## Demo

![Tab Navigator Backspace close demo](https://github.com/user-attachments/assets/d2e20442-52d4-4a4a-bbec-c1b26009831d)

The animation demonstrates:

1. Closing the selected tab from three tabs to two.
2. Keeping the Navigator open after the close.
3. Closing another tab and keeping the remaining tab in the Navigator.

The recording intentionally stops in the Navigator. Pressing `Backspace` once more exits the Navigator and keeps the final tab and window open.

### Before and after

| Before | After |
|---|---|
| ![Before closing](https://github.com/user-attachments/assets/59dd7e51-78e1-4bdc-900c-827b763e12dc) | ![After closing](https://github.com/user-attachments/assets/198afab2-3e08-44af-9e09-85b1b4a520f4) |

## Behavior

| Situation | Result |
|---|---|
| Multiple tabs | Close the selected tab and keep the Navigator open |
| One tab remaining | Exit the Navigator without closing the tab or window |
| Filtering | Delete a filter character instead of closing a tab |
| Running process | Show the existing close confirmation |
| Confirmation accepted | Close the tab and return to the Navigator |
| Confirmation cancelled | Keep the tab and return to the Navigator |
| Custom launcher | Preserve the existing Backspace behavior |

## Implementation

- Associate each Navigator pane entry with its stable `TabId`.
- Send a close action from the Launcher instead of deleting the tab directly.
- Re-read the live mux state before closing, so tab reordering cannot close the wrong tab.
- Re-check the live tab count after a confirmation before removing the target.
- Limit the new Backspace behavior to the built-in Tab Navigator.

## Testing

- `make fmt-check`
- `cargo check -p kaku-gui`
- `cargo test --offline -p kaku-gui`
  - 558 tests passed
  - 1 network-dependent update test remained intentionally ignored
- `CARGO_NET_OFFLINE=true make app`
- Manual GUI smoke:
  - three tabs → two tabs
  - two tabs → one tab
  - final-tab Backspace exits the Navigator without closing the window
