### PR TITLE
fix(rename): match text alignment to tab bar position

### DIFF
--- a/kaku-gui/src/termwindow/tab_rename.rs
+++ b/kaku-gui/src/termwindow/tab_rename.rs
@@ -801,12 +801,12 @@ impl TabRenameModal {
         let x = x.min(anchor_right - min_width).min(max_x).max(0.0);
 
         let row = Element::new(&font, ElementContent::Children(row))
-            .vertical_align(VerticalAlign::Bottom)
+            .vertical_align(VerticalAlign::Middle)
             .margin(BoxDimension {
                 left: Dimension::Pixels(0.0),
                 right: Dimension::Pixels(0.0),
-                top: Dimension::Pixels(0.5),
-                bottom: Dimension::Cells(0.1),
+                top: Dimension::Pixels(0.0),
+                bottom: Dimension::Cells(0.0),
             });
         let content_min_width = Self::content_min_extent(
             min_width,


### PR DESCRIPTION
# Summary

Tab rename modal text was always bottom-aligned. When tab bar is at top (default), text now aligns adjacent to tab item being renamed.

# Changes

 - `kaku-gui/src/termwindow/tab_rename.rs` — Vertical align from Bottom to Middle, top/bottom margins zeroed. Text sits closer to tab bar edge, visually connected to tab being renamed.

## Before

<img width="1121" height="768" alt="image" src="https://github.com/user-attachments/assets/7882d434-76d7-4410-9b0b-09834bfcbe0c" />

## After 

<img width="1141" height="675" alt="image" src="https://github.com/user-attachments/assets/dee011aa-89a7-41e5-9a1e-9befcb9249af" />

