### PR TITLE
fix(render): clamp draw counts to quad buffer capacity

### DIFF
--- a/kaku-gui/src/renderstate.rs
+++ b/kaku-gui/src/renderstate.rs
@@ -362,8 +362,18 @@ impl TripleVertexBuffer {
         }
     }
 
+    /// Number of vertices/indices to draw for this buffer.
+    ///
+    /// `next_quad` deliberately keeps counting past `capacity` so that
+    /// `need_more_quads()` can report the shortfall and grow the GPU
+    /// buffers. The staging layer only ever writes `capacity` quads worth
+    /// of vertices, and the index buffer only contains `capacity` quads
+    /// worth of indices, so the draw call must be clamped to the capacity.
+    /// Returning the unclamped count makes glium's `slice()` yield `None`
+    /// and wgpu raise `Index N extends beyond limit M`, aborting the
+    /// process on any frame that fails to converge.
     pub fn vertex_index_count(&self) -> (usize, usize) {
-        let num_quads = *self.next_quad.borrow();
+        let num_quads = (*self.next_quad.borrow()).min(self.capacity);
         (num_quads * VERTICES_PER_CELL, num_quads * INDICES_PER_CELL)
     }
 

--- a/kaku-gui/src/termwindow/render/draw.rs
+++ b/kaku-gui/src/termwindow/render/draw.rs
@@ -254,9 +254,26 @@ impl crate::TermWindow {
                     uniforms.add_struct("blink", &blink);
                     uniforms.add_struct("rapid_blink", &rapid_blink);
 
+                    let vertex_slice =
+                        vertices.glium().slice(0..vertex_count).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "vertex buffer slice 0..{} is out of range for layer {}",
+                                vertex_count,
+                                idx
+                            )
+                        })?;
+                    let index_slice =
+                        vb.indices.glium().slice(0..index_count).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "index buffer slice 0..{} is out of range for layer {}",
+                                index_count,
+                                idx
+                            )
+                        })?;
+
                     frame.draw(
-                        vertices.glium().slice(0..vertex_count).unwrap(),
-                        vb.indices.glium().slice(0..index_count).unwrap(),
+                        vertex_slice,
+                        index_slice,
                         gl_state.glyph_prog.as_ref().unwrap(),
                         &uniforms,
                         if subpixel_aa {

--- a/kaku-gui/src/termwindow/render/paint.rs
+++ b/kaku-gui/src/termwindow/render/paint.rs
@@ -115,13 +115,19 @@ impl crate::TermWindow {
         // Limit retries to prevent a busy-loop when render state cannot converge
         // (e.g. during display reconfiguration after lock-screen return).
         const MAX_PAINT_RETRIES: usize = 8;
+        // Set while the most recent pass had to grow the quad buffers: the
+        // vertices staged by that pass were truncated to the old capacity,
+        // so the frame we are about to draw is incomplete.
+        let mut quads_grew = false;
         'pass: for pass in 0..MAX_PAINT_RETRIES {
             match self.paint_pass() {
                 Ok(_) => match self.render_state.as_mut().unwrap().allocated_more_quads() {
                     Ok(allocated) => {
                         if !allocated {
+                            quads_grew = false;
                             break 'pass;
                         }
+                        quads_grew = true;
                         self.invalidate_fancy_tab_bar();
                         self.invalidate_modal();
                     }
@@ -191,6 +197,21 @@ impl crate::TermWindow {
                 200,
                 start.elapsed().as_millis()
             );
+        }
+
+        if quads_grew {
+            // We ran out of passes while still growing the quad buffers, so
+            // this frame is drawn with truncated geometry. The buffers are
+            // now large enough, so ask for one more frame to fill it in
+            // rather than leaving a partially rendered window on screen.
+            log::warn!(
+                "paint_pass did not converge within {} passes; \
+                 quad buffers were grown, repainting",
+                MAX_PAINT_RETRIES
+            );
+            if let Some(window) = self.window.as_ref() {
+                window.invalidate();
+            }
         }
 
         log::debug!("paint_impl before call_draw elapsed={:?}", start.elapsed());


### PR DESCRIPTION
## Problem

Kaku V0.16.0 crash-loops on launch (SIGABRT) whenever a paint pass fails to converge. On my machine (macOS 26.5.2, M4 Pro, `front_end = 'OpenGL'`) it reproduces 100% of the time from a session snapshot that contains a horizontal split where **both** panes have restored scrollback:

```
INFO  kaku_gui > auto-restored previous session from snapshot
WARN  kaku_gui::termwindow::render::paint > paint_impl retry loop exceeded 200ms (604ms), likely display reconfiguration
ERROR env_bootstrap > panic at kaku-gui/src/termwindow/render/draw.rs:258:65 -
      called `Option::unwrap()` on a `None` value
```

Because the same snapshot is auto-restored on every launch, the app dies on each start until `~/.config/kaku/last_session.json` is deleted by hand. macOS then stacks its "reopen windows?" restore prompt on top, which is what the crash report surfaces (`-[NSPersistentUIRestorer promptToIgnorePersistentStateWithCrashHistory:]` → `-[_NSOpenGLViewBackingLayer display]` → `abort`), hiding the actual Rust panic. 14 consecutive `.ips` reports in ~40 seconds.

Not backend-specific — with `--config 'front_end="WebGpu"'` the same frame fails with a much more explicit message:

```
wgpu error: Validation Error
  In RenderPass::end / In a draw command, kind: Draw
    Index 23118 extends beyond limit 192. Did you bind the correct index buffer?
```

## Root cause

`StagingLayer::allocate()` deliberately keeps incrementing `next_quad` past `capacity` so that `need_more_quads()` can report the shortfall and `allocated_more_quads()` can grow the GPU buffers. It only ever *writes* `capacity` quads worth of vertices, and `compute_vertices()` only emits `capacity` quads worth of indices.

`TripleVertexBuffer::vertex_index_count()` returned the **unclamped** `next_quad`, so any frame that reaches `call_draw()` while still over capacity indexes past the end of both buffers:

- glium: `slice(0..vertex_count)` returns `None` → `unwrap()` aborts the process.
- wgpu: `draw_indexed` validation error → also fatal (`limit 192` = the 32-quad sub-buffers `RenderLayer::new` allocates for vb 0 and 2).

That normally never happens because the retry loop repaints until `allocated_more_quads()` returns false — but `MAX_PAINT_RETRIES` (8) and the `break 'pass` error paths can both leave the loop with `next_quad > capacity`, and the very next statement is `self.call_draw(frame)?`. A heavy first frame (split + two restored scrollbacks) hits exactly that.

## Changes

- `vertex_index_count()` clamps to `capacity`. An unconverged frame renders truncated instead of aborting the process.
- The two `unwrap()`s in the glium draw path become errors, so any future mismatch is logged instead of fatal.
- `paint_impl` tracks whether it left the retry loop while still growing quad buffers, and invalidates the window so the truncated frame is immediately followed by a complete one instead of staying half-drawn.

## Verification

| Build | Result with the offending snapshot |
|---|---|
| V0.16.0 release | aborts on every launch (3/3) |
| this patch, clamp reverted, error path kept | survives, logs `vertex buffer slice 0..15288 is out of range for layer 0` — confirms the overflow is exactly what used to abort |
| this patch, full | session restores and renders cleanly, no warnings |

`make fmt-check`, `make check`, `make test` (1296 + 15 tests, all pass).

No unit test added: `TripleVertexBuffer` can only be constructed through a live `RenderContext`, so the clamp isn't reachable without a GPU device in the test harness. Happy to add one if you'd like a fake context for it.
