### PR TITLE
[codex] Fix lazygit shortcut in nested terminals

### DIFF
--- a/assets/macos/Kaku.app/Contents/Resources/kaku.lua
+++ b/assets/macos/Kaku.app/Contents/Resources/kaku.lua
@@ -2918,18 +2918,6 @@ local function launch_lazygit(window, pane)
     return
   end
 
-  local path = pane_cwd(pane)
-  if path == "" then
-    show_lazygit_toast(window, pane, "kaku-toast-lazygit-no-cwd")
-    return
-  end
-
-  local repo_root = detect_git_repo_root(path)
-  if not repo_root then
-    show_lazygit_toast(window, pane, "kaku-toast-lazygit-not-git")
-    return
-  end
-
   local lazygit_cmd = resolve_lazygit_command()
   if not lazygit_cmd then
     show_lazygit_toast(window, pane, "kaku-toast-lazygit-missing")
@@ -2948,7 +2936,10 @@ local function launch_lazygit(window, pane)
     show_lazygit_toast(window, pane, "kaku-toast-lazygit-dispatch-failed")
     return
   end
-  mark_repo_lazygit_used(repo_root)
+  -- The shell that receives this input owns the real working directory. In a
+  -- nested terminal (for example Herdr or tmux), Kaku's outer pane cwd can be
+  -- stale, so do not preflight Git here. Lazygit reports a non-repository
+  -- directory itself after the current shell resolves the command.
 end
 
 local function launch_yazi(window, pane)

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1180,6 +1180,34 @@ return tab, {{ tab }}, panes, effective_config
     }
 
     #[test]
+    fn bundled_kaku_lazygit_dispatch_does_not_require_outer_pane_git_cwd() {
+        let bundled = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../assets/macos/Kaku.app/Contents/Resources/kaku.lua");
+        let content = std::fs::read_to_string(&bundled).expect("read bundled kaku.lua");
+        let launch_start = content
+            .find("local function launch_lazygit(window, pane)")
+            .expect("bundled kaku.lua should define launch_lazygit");
+        let launch = &content[launch_start..];
+        let launch_end = launch
+            .find("\nlocal function launch_yazi")
+            .expect("launch_lazygit should end before launch_yazi");
+        let launch = &launch[..launch_end];
+
+        assert!(
+            !launch.contains("detect_git_repo_root(path)"),
+            "lazygit dispatch must not reject an outer pane cwd; nested shells own their real PWD"
+        );
+        assert!(
+            !launch.contains("kaku-toast-lazygit-not-git"),
+            "lazygit dispatch must let lazygit report non-git directories itself"
+        );
+        assert!(
+            launch.contains("wezterm.action.SendString(\"\\x15\" .. lazygit_cmd .. \"\\r\")"),
+            "lazygit dispatch should retain the clear-line then command send sequence"
+        );
+    }
+
+    #[test]
     fn bundled_kaku_lua_sets_colorfgbg_from_user_theme_scan() {
         let bundled = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../assets/macos/Kaku.app/Contents/Resources/kaku.lua");


### PR DESCRIPTION
## Summary

Fixes #531.

`Cmd+Shift+G` could show `Lazygit: Not a git repository` even when the current interactive Fish shell had already entered a valid Git repository with `zi` or `cd`. The problem is not specific to Herdr or tmux: Kaku's cached/OSC 7 pane cwd can lag behind the shell's real `$PWD`, so the old Git preflight checked the wrong directory and blocked dispatch.

The shortcut still belongs to Kaku, but it now checks only that lazygit is installed and sends `Ctrl+U + lazygit + Enter` to the current terminal input stream. The receiving shell or multiplexer resolves the command using its actual focused-pane `$PWD`. If that directory is not a Git repository, lazygit reports the native error itself.

## Changes

- Remove the outer-pane cwd and Git preflight from `launch_lazygit`.
- Preserve the missing-lazygit and dispatch-failure feedback.
- Preserve clear-line-before-send behavior.
- Add a regression guard preventing reintroduction of the outer cwd Git rejection.

## Validation

- `cargo test -p config`
- `make fmt-check`
- `make app`
- `luajit -e "assert(loadfile('assets/macos/Kaku.app/Contents/Resources/kaku.lua'))"`

## Manual verification

1. Start Kaku in a non-Git directory.
2. In a normal Fish pane, use `zi` to enter a Git repository.
3. Confirm `pwd` and `git status` show the repository.
4. Press Cmd+Shift+G.
5. Lazygit should open in the repository selected by Fish, without relying on Kaku's cached pane cwd.

The same flow also covers Herdr and tmux nested panes.
