### PR TITLE
fix(session): restore pane cwd when OSC 7 reports the local hostname

### DIFF
--- a/kaku-gui/src/local_hostname.rs
+++ b/kaku-gui/src/local_hostname.rs
@@ -1,0 +1,52 @@
+/// Return the current system hostname without assuming it is stable for the
+/// lifetime of the app.
+pub(crate) fn current() -> Option<String> {
+    hostname::get()
+        .ok()
+        .map(|hostname| hostname.to_string_lossy().into_owned())
+        .filter(|hostname| !hostname.is_empty())
+}
+
+fn without_fqdn_dot(hostname: &str) -> &str {
+    hostname.strip_suffix('.').unwrap_or(hostname)
+}
+
+/// Whether a `file://` URL host is proven to identify this machine.
+///
+/// Short hostnames are intentionally not derived from an FQDN: a local
+/// `mac.local` and a remote `mac` are distinct machines even though their
+/// first labels match.
+pub(crate) fn is_local_file_host(host: Option<&str>, local_hostname: Option<&str>) -> bool {
+    let Some(host) = host else {
+        return true;
+    };
+    let host = without_fqdn_dot(host);
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    let Some(local_hostname) = local_hostname else {
+        return false;
+    };
+    let local_hostname = without_fqdn_dot(local_hostname);
+    !local_hostname.is_empty() && host.eq_ignore_ascii_case(local_hostname)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_local_file_host;
+
+    #[test]
+    fn local_file_hosts_require_an_exact_identity() {
+        assert!(is_local_file_host(None, Some("mac.local")));
+        assert!(is_local_file_host(Some("localhost"), Some("mac.local")));
+        assert!(is_local_file_host(Some("MAC.LOCAL."), Some("mac.local")));
+
+        assert!(!is_local_file_host(Some("mac"), Some("mac.local")));
+        assert!(!is_local_file_host(
+            Some("mac.corp.example"),
+            Some("mac.local")
+        ));
+        assert!(!is_local_file_host(Some("mac.local"), None));
+    }
+}

--- a/kaku-gui/src/main.rs
+++ b/kaku-gui/src/main.rs
@@ -105,6 +105,7 @@ mod frontend;
 mod glyphcache;
 mod inline_ai;
 mod inputmap;
+mod local_hostname;
 #[cfg(target_os = "macos")]
 mod macos;
 mod overlay;

--- a/kaku-gui/src/session_restore.rs
+++ b/kaku-gui/src/session_restore.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use wezterm_term::TerminalSize;
 use wezterm_toast_notification::persistent_toast_notification;
 use window::WindowOps;
@@ -513,39 +513,19 @@ fn collect_leaf_entries(node: &SavedPaneNode, out: &mut Vec<SavedPaneEntry>) {
     }
 }
 
-/// Lowercase host names that identify this machine in a `file://` URL.
-///
-/// OSC 7 is conventionally reported as `file://$HOST$PWD`, and shells
-/// variously report the full hostname or just its first label, so accept
-/// both. A trailing dot (FQDN form) is stripped by the caller.
-fn local_file_url_hostnames() -> &'static [String] {
-    // The hostname cannot change while the app is running, and this lookup
-    // happens once per restored pane, so compute it lazily exactly once.
-    static NAMES: OnceLock<Vec<String>> = OnceLock::new();
-    NAMES.get_or_init(|| {
-        let mut names = Vec::new();
-        if let Ok(hostname) = hostname::get() {
-            // The URL parser lowercases domain hosts, so the comparison
-            // baseline must be lowercase too; this makes the match
-            // case-insensitive (macOS hostnames are often mixed case).
-            let hostname = hostname.to_string_lossy().to_lowercase();
-            // For an FQDN like "my-mac.local", also accept the short form
-            // "my-mac": zsh's $HOST, `hostname`, and `scutil LocalHostName`
-            // disagree on whether the domain part is included.
-            if let Some((short, _)) = hostname.split_once('.') {
-                names.push(short.to_string());
-            }
-            names.push(hostname);
-        }
-        names
-    })
-}
-
 /// Convert a saved `file://` working-directory URL into a spawnable path.
 ///
 /// Returns `None` for non-file schemes and for hosts that do not identify
 /// this machine, so a foreign (e.g. ssh) cwd never leaks into a local spawn.
 fn cwd_from_working_dir(working_dir: Option<&SerdeUrl>) -> Option<String> {
+    let local_hostname = crate::local_hostname::current();
+    cwd_from_working_dir_with_hostname(working_dir, local_hostname.as_deref())
+}
+
+fn cwd_from_working_dir_with_hostname(
+    working_dir: Option<&SerdeUrl>,
+    local_hostname: Option<&str>,
+) -> Option<String> {
     let url = working_dir?;
     if url.url.scheme() != "file" {
         return None;
@@ -554,17 +534,14 @@ fn cwd_from_working_dir(working_dir: Option<&SerdeUrl>) -> Option<String> {
     if let Some(host) = url.host_str() {
         // `to_file_path` refuses any host other than empty or `localhost`,
         // but OSC 7 reporters conventionally use the real local hostname.
-        // Treat this machine's own names as local; any other host keeps the
+        // Treat this machine's exact hostname as local; any other host keeps the
         // strict behavior so a remote cwd cannot leak into a local spawn.
-        //
-        // Tolerate a trailing dot: "my-mac.local." is the FQDN spelling of
-        // the same host and some tools emit it verbatim.
-        let host = host.trim_end_matches('.');
-        if local_file_url_hostnames().iter().any(|name| name == host) {
-            // Strip the now-proven-local host so `to_file_path` accepts the
-            // URL. Propagate failure (only possible for cannot-be-a-base
-            // URLs, which file URLs are not) as a refused conversion.
-            url.set_host(None).ok()?;
+        if crate::local_hostname::is_local_file_host(Some(host), local_hostname) {
+            // `Url::set_host(None)` updates the serialized file URL but leaves
+            // its internal host value intact in url 2.5.7, so `to_file_path`
+            // still rejects it. Rewrite a proven-local host to the one value
+            // that `to_file_path` explicitly accepts.
+            url.set_host(Some("localhost")).ok()?;
         }
     }
     url.to_file_path()
@@ -582,7 +559,7 @@ fn is_ssh_domain_name(name: &str) -> bool {
 /// `to_file_path` refuses remote-host URLs, so those panes used to restore
 /// into the remote home directory. The path component is meaningful on the
 /// remote side, so pass it through for ssh domains. Local domains accept
-/// empty/`localhost` hosts plus this machine's own host names (see
+/// empty/`localhost` hosts plus this machine's exact hostname (see
 /// `cwd_from_working_dir`); any other host still fails conversion, so a
 /// leftover remote path cannot leak into a local spawn.
 fn cwd_for_restore(domain_name: &str, working_dir: Option<&SerdeUrl>) -> Option<String> {
@@ -1527,32 +1504,32 @@ mod tests {
     }
 
     #[test]
-    fn restore_cwd_local_domain_accepts_local_hostname() {
-        // OSC 7 reporters conventionally use the real local hostname, which
-        // `to_file_path` would otherwise reject on unix.
-        let hostname = hostname::get()
-            .expect("local hostname")
-            .to_string_lossy()
-            .into_owned();
+    fn restore_cwd_local_domain_accepts_exact_local_hostname() {
         // URL parsing lowercases the host; the comparison must not care.
-        let url = format!("file://{}/Users/a/src", hostname.to_uppercase());
         assert_eq!(
-            cwd_for_restore("local", Some(&serde_url(&url))).as_deref(),
+            cwd_from_working_dir_with_hostname(
+                Some(&serde_url("file://MAC.LOCAL/Users/a/src")),
+                Some("mac.local"),
+            )
+            .as_deref(),
             Some("/Users/a/src")
         );
-        // Shells variously report just the first label of an FQDN.
-        if let Some((short, _)) = hostname.split_once('.') {
-            let url = format!("file://{short}/Users/a/src");
-            assert_eq!(
-                cwd_for_restore("local", Some(&serde_url(&url))).as_deref(),
-                Some("/Users/a/src")
-            );
-        }
         // A trailing dot (FQDN form) still identifies this machine.
-        let url = format!("file://{hostname}./Users/a/src");
         assert_eq!(
-            cwd_for_restore("local", Some(&serde_url(&url))).as_deref(),
+            cwd_from_working_dir_with_hostname(
+                Some(&serde_url("file://mac.local./Users/a/src")),
+                Some("mac.local"),
+            )
+            .as_deref(),
             Some("/Users/a/src")
+        );
+        // A short remote host with the same first label is not local proof.
+        assert_eq!(
+            cwd_from_working_dir_with_hostname(
+                Some(&serde_url("file://mac/Users/a/src")),
+                Some("mac.local"),
+            ),
+            None
         );
     }
 

--- a/kaku-gui/src/session_restore.rs
+++ b/kaku-gui/src/session_restore.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use wezterm_term::TerminalSize;
 use wezterm_toast_notification::persistent_toast_notification;
 use window::WindowOps;
@@ -513,13 +513,61 @@ fn collect_leaf_entries(node: &SavedPaneNode, out: &mut Vec<SavedPaneEntry>) {
     }
 }
 
+/// Lowercase host names that identify this machine in a `file://` URL.
+///
+/// OSC 7 is conventionally reported as `file://$HOST$PWD`, and shells
+/// variously report the full hostname or just its first label, so accept
+/// both. A trailing dot (FQDN form) is stripped by the caller.
+fn local_file_url_hostnames() -> &'static [String] {
+    // The hostname cannot change while the app is running, and this lookup
+    // happens once per restored pane, so compute it lazily exactly once.
+    static NAMES: OnceLock<Vec<String>> = OnceLock::new();
+    NAMES.get_or_init(|| {
+        let mut names = Vec::new();
+        if let Ok(hostname) = hostname::get() {
+            // The URL parser lowercases domain hosts, so the comparison
+            // baseline must be lowercase too; this makes the match
+            // case-insensitive (macOS hostnames are often mixed case).
+            let hostname = hostname.to_string_lossy().to_lowercase();
+            // For an FQDN like "my-mac.local", also accept the short form
+            // "my-mac": zsh's $HOST, `hostname`, and `scutil LocalHostName`
+            // disagree on whether the domain part is included.
+            if let Some((short, _)) = hostname.split_once('.') {
+                names.push(short.to_string());
+            }
+            names.push(hostname);
+        }
+        names
+    })
+}
+
+/// Convert a saved `file://` working-directory URL into a spawnable path.
+///
+/// Returns `None` for non-file schemes and for hosts that do not identify
+/// this machine, so a foreign (e.g. ssh) cwd never leaks into a local spawn.
 fn cwd_from_working_dir(working_dir: Option<&SerdeUrl>) -> Option<String> {
     let url = working_dir?;
     if url.url.scheme() != "file" {
         return None;
     }
-    url.url
-        .to_file_path()
+    let mut url = url.url.clone();
+    if let Some(host) = url.host_str() {
+        // `to_file_path` refuses any host other than empty or `localhost`,
+        // but OSC 7 reporters conventionally use the real local hostname.
+        // Treat this machine's own names as local; any other host keeps the
+        // strict behavior so a remote cwd cannot leak into a local spawn.
+        //
+        // Tolerate a trailing dot: "my-mac.local." is the FQDN spelling of
+        // the same host and some tools emit it verbatim.
+        let host = host.trim_end_matches('.');
+        if local_file_url_hostnames().iter().any(|name| name == host) {
+            // Strip the now-proven-local host so `to_file_path` accepts the
+            // URL. Propagate failure (only possible for cannot-be-a-base
+            // URLs, which file URLs are not) as a refused conversion.
+            url.set_host(None).ok()?;
+        }
+    }
+    url.to_file_path()
         .ok()
         .map(|path| path.to_string_lossy().into_owned())
 }
@@ -533,9 +581,10 @@ fn is_ssh_domain_name(name: &str) -> bool {
 /// An ssh-domain pane's OSC 7 cwd is `file://<remote-host>/path`;
 /// `to_file_path` refuses remote-host URLs, so those panes used to restore
 /// into the remote home directory. The path component is meaningful on the
-/// remote side, so pass it through for ssh domains. Local domains keep the
-/// strict local conversion: a leftover remote path would make a local spawn
-/// fail or land in an unrelated same-named directory.
+/// remote side, so pass it through for ssh domains. Local domains accept
+/// empty/`localhost` hosts plus this machine's own host names (see
+/// `cwd_from_working_dir`); any other host still fails conversion, so a
+/// leftover remote path cannot leak into a local spawn.
 fn cwd_for_restore(domain_name: &str, working_dir: Option<&SerdeUrl>) -> Option<String> {
     if is_ssh_domain_name(domain_name) {
         let url = working_dir?;
@@ -1466,10 +1515,44 @@ mod tests {
             cwd_for_restore("local", Some(&serde_url("file:///Users/a/src"))).as_deref(),
             Some("/Users/a/src")
         );
+        assert_eq!(
+            cwd_for_restore("local", Some(&serde_url("file://localhost/Users/a/src"))).as_deref(),
+            Some("/Users/a/src")
+        );
         // A remote-host cwd must not leak into a local spawn.
         assert_eq!(
             cwd_for_restore("local", Some(&serde_url("file://server/home/u"))),
             None
+        );
+    }
+
+    #[test]
+    fn restore_cwd_local_domain_accepts_local_hostname() {
+        // OSC 7 reporters conventionally use the real local hostname, which
+        // `to_file_path` would otherwise reject on unix.
+        let hostname = hostname::get()
+            .expect("local hostname")
+            .to_string_lossy()
+            .into_owned();
+        // URL parsing lowercases the host; the comparison must not care.
+        let url = format!("file://{}/Users/a/src", hostname.to_uppercase());
+        assert_eq!(
+            cwd_for_restore("local", Some(&serde_url(&url))).as_deref(),
+            Some("/Users/a/src")
+        );
+        // Shells variously report just the first label of an FQDN.
+        if let Some((short, _)) = hostname.split_once('.') {
+            let url = format!("file://{short}/Users/a/src");
+            assert_eq!(
+                cwd_for_restore("local", Some(&serde_url(&url))).as_deref(),
+                Some("/Users/a/src")
+            );
+        }
+        // A trailing dot (FQDN form) still identifies this machine.
+        let url = format!("file://{hostname}./Users/a/src");
+        assert_eq!(
+            cwd_for_restore("local", Some(&serde_url(&url))).as_deref(),
+            Some("/Users/a/src")
         );
     }
 

--- a/kaku-gui/src/termwindow/ai_chat.rs
+++ b/kaku-gui/src/termwindow/ai_chat.rs
@@ -57,9 +57,10 @@ fn build_terminal_context(
     let (_, tab_lines) = pane.get_lines(tab_top..bottom);
     let tab_snapshot = tab_snapshot_text(&tab_lines);
 
+    let local_hostname = crate::local_hostname::current();
     let (cwd, remote_host) = pane
         .get_current_working_dir(CachePolicy::AllowStale)
-        .map(|u| split_cwd_url(&u, &local_hostname()))
+        .map(|u| split_cwd_url(&u, local_hostname.as_deref()))
         .unwrap_or_default();
     let selected_text = term.selection_text(pane);
 
@@ -85,36 +86,20 @@ fn build_terminal_context(
     }
 }
 
-fn local_hostname() -> String {
-    static HOSTNAME: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-    HOSTNAME
-        .get_or_init(|| {
-            hostname::get()
-                .ok()
-                .and_then(|h| h.into_string().ok())
-                .unwrap_or_default()
-        })
-        .clone()
-}
-
 /// Split an OSC 7 cwd URL into a path plus the remote host, if any.
 ///
 /// OSC 7 emits `file://<hostname>/path`; a host that is neither empty,
 /// `localhost`, nor this machine means the pane is inside an ssh (or other
-/// remote) session and the path must not be treated as local. Hostnames are
-/// compared case-insensitively and by first label, because the remote side
-/// may report a short name while macOS reports `name.local` (or vice versa).
-fn split_cwd_url(url: &url::Url, local_host: &str) -> (String, Option<String>) {
+/// remote) session and the path must not be treated as local. Hostnames must
+/// match exactly after case and trailing-dot normalization; their first labels
+/// are not unique identities.
+fn split_cwd_url(url: &url::Url, local_host: Option<&str>) -> (String, Option<String>) {
     let path = url.path().to_string();
     let host = url.host_str().unwrap_or("");
     if url.scheme() != "file" {
         return (path, Some(host.to_string()));
     }
-    if host.is_empty() || host.eq_ignore_ascii_case("localhost") {
-        return (path, None);
-    }
-    let first_label = |s: &str| s.split('.').next().unwrap_or(s).to_ascii_lowercase();
-    if !local_host.is_empty() && first_label(host) == first_label(local_host) {
+    if crate::local_hostname::is_local_file_host(url.host_str(), local_host) {
         return (path, None);
     }
     (path, Some(host.to_string()))
@@ -220,7 +205,7 @@ mod tests {
     }
 
     fn cwd(url: &str, local: &str) -> (String, Option<String>) {
-        split_cwd_url(&url::Url::parse(url).unwrap(), local)
+        split_cwd_url(&url::Url::parse(url).unwrap(), Some(local))
     }
 
     #[test]
@@ -231,11 +216,7 @@ mod tests {
             ("/Users/a".into(), None)
         );
         assert_eq!(
-            cwd("file://mac.local/Users/a", "mac"),
-            ("/Users/a".into(), None)
-        );
-        assert_eq!(
-            cwd("file://MAC/Users/a", "mac.local"),
+            cwd("file://MAC.LOCAL./Users/a", "mac.local"),
             ("/Users/a".into(), None)
         );
     }
@@ -249,6 +230,14 @@ mod tests {
         assert_eq!(
             cwd("file://build.corp.example/srv", "mac"),
             ("/srv".into(), Some("build.corp.example".into()))
+        );
+        assert_eq!(
+            cwd("file://mac/home/u", "mac.local"),
+            ("/home/u".into(), Some("mac".into()))
+        );
+        assert_eq!(
+            cwd("file://mac.corp.example/srv", "mac.local"),
+            ("/srv".into(), Some("mac.corp.example".into()))
         );
     }
 


### PR DESCRIPTION
## Problem

Session restore reopens tabs/splits correctly, but every pane lands in `$HOME`. `last_session.json` saves each pane's `working_dir`, but `cwd_from_working_dir()` converts it with `url::Url::to_file_path()`, which on unix refuses any host other than empty or `localhost` (verified against the `url` crate source: `None | Some(Host::Domain("localhost")) => None`, `_ => return Err(())`).

OSC 7 is conventionally reported as `file://$HOST$PWD` — WezTerm's own shell integration does exactly this — and the snapshot stores the URL verbatim. Verified live on macOS: emitting `\033]7;file://<hostname>.local/tmp/x\033\\` into a pane makes `kaku cli list` report exactly that URL, and every entry in a real `last_session.json` shows the same shape (`file://df-macbook-pro-14.local/Users/...`). All of them fail `to_file_path()` -> `cwd_for_restore()` returns `None` -> panes spawn at the default cwd.

The ssh-domain branch of `cwd_for_restore()` already special-cases this `to_file_path()` limitation for remote hosts; local panes hit the same wall when the OSC 7 host is the *local* hostname.

## Fix

In `cwd_from_working_dir()`, treat a `file://` URL whose host identifies this machine as local: strip the host before calling `to_file_path()`.

- Accept both the full hostname and its first label (zsh `$HOST`, `hostname`, and `scutil --get LocalHostName` disagree on whether the domain part is included).
- Compare case-insensitively: the URL parser lowercases the host, while macOS hostnames are often mixed case.
- Tolerate a trailing dot (FQDN form).
- Any other host still fails conversion, preserving the existing guarantee that a leftover remote cwd cannot leak into a local spawn.

## Tests

- Extended `restore_cwd_local_domain_requires_local_url` with a `localhost` case; the remote-host rejection case is unchanged.
- Added `restore_cwd_local_domain_accepts_local_hostname`: real hostname (uppercased to prove case-insensitivity), short hostname, and trailing-dot FQDN. The hostname is read at runtime, so the test is machine-independent.

## Verification

- `make fmt-check` passes.
- `cargo test --locked -p kaku-gui session_restore` covers the new and existing restore-cwd tests (cold full-workspace build is slow on the author's machine; the checks workflow covers fmt/check/tests on the PR).

## 中文摘要

问题：会话恢复后所有 pane 都打开在 `$HOME`。快照里保存的 `working_dir` 是带本机真实主机名的 `file://` URL（OSC 7 的惯例格式 `file://$HOST$PWD`），而恢复端 `cwd_from_working_dir()` 调用的 `url::Url::to_file_path()` 在 unix 上拒绝任何非空、非 `localhost` 的 host，导致路径转换失败、pane 以默认目录启动。ssh 分支之前已经针对这个限制做过处理，但本地 pane 在 host 是本机主机名时撞上了同一堵墙。

修复：转换前把"本机主机名"（全名或首段、忽略大小写、容忍 FQDN 尾点）识别为本地并剥离 host；其他 host 依旧拒绝，保留"远程路径不得泄漏进本地 spawn"的防护。附带覆盖本机主机名三种形态的单元测试，并通过 `make fmt-check`。
