### PR TITLE
fix(ai): prefer configured model after provider switch

### DIFF
--- a/kaku-gui/src/ai_state.rs
+++ b/kaku-gui/src/ai_state.rs
@@ -11,7 +11,7 @@
 //! | Surface | Path | TTL | Purpose |
 //! |---|---|---|---|
 //! | `kaku ai` TUI | `~/.cache/kaku/assistant_models.json` | 30 min, base_url-keyed | Driving the dropdown picker; refreshed every TUI session so a freshly-added model shows up. |
-//! | Cmd+L overlay (here) | `~/.config/kaku/ai_chat_state.json` `cached_models` | persistent, no expiry | Avoid a "loading models…" flash on the very next overlay open; merged with `chat_model` and the curated `chat_model_choices` list. |
+//! | Cmd+L overlay (here) | `~/.config/kaku/ai_chat_state.json` `cached_models` | persistent, endpoint-keyed | Show the last list while the same endpoint refreshes. Cached entries are never trusted for the active selection until that refresh succeeds. |
 //!
 //! Merging them would force one TTL policy on both surfaces and add a
 //! cross-binary file lock. The caches are tiny (a list of model IDs) and the
@@ -29,6 +29,10 @@ struct StateFile {
     /// Cached model list from the last successful /models fetch.
     #[serde(default)]
     cached_models: Vec<String>,
+    /// Identifies the auth transport and endpoint that produced `cached_models`.
+    /// Legacy state files do not have this field; their unscoped cache is ignored.
+    #[serde(default)]
+    cached_models_key: Option<String>,
 }
 
 /// Load the last selected model from disk. Returns None on any error (non-fatal).
@@ -36,13 +40,21 @@ pub fn load_last_model() -> Option<String> {
     try_load().ok().flatten().and_then(|f| f.last_model)
 }
 
-/// Load the cached model list from the previous session.
-pub fn load_cached_models() -> Vec<String> {
+/// Load the cached model list only when it belongs to the current endpoint.
+pub fn load_cached_models(cache_key: &str) -> Vec<String> {
     try_load()
         .ok()
         .flatten()
-        .map(|f| f.cached_models)
+        .map(|file| cached_models_for_key(file, cache_key))
         .unwrap_or_default()
+}
+
+fn cached_models_for_key(file: StateFile, cache_key: &str) -> Vec<String> {
+    if file.cached_models_key.as_deref() == Some(cache_key) {
+        file.cached_models
+    } else {
+        vec![]
+    }
 }
 
 fn try_load() -> Result<Option<StateFile>> {
@@ -69,17 +81,18 @@ fn load_or_default() -> StateFile {
 pub fn save_last_model(model: &str) -> Result<()> {
     let path = state_path()?;
     let mut file = load_or_default();
-    file.version = 1;
+    file.version = 2;
     file.last_model = Some(model.to_string());
     write_state(&path, &file)
 }
 
-/// Persist the fetched model list so the next session starts without a loading delay.
-pub fn save_cached_models(models: &[String]) -> Result<()> {
+/// Persist a fetched model list together with its endpoint identity.
+pub fn save_cached_models(cache_key: &str, models: &[String]) -> Result<()> {
     let path = state_path()?;
     let mut file = load_or_default();
-    file.version = 1;
+    file.version = 2;
     file.cached_models = models.to_vec();
+    file.cached_models_key = Some(cache_key.to_string());
     write_state(&path, &file)
 }
 
@@ -98,4 +111,34 @@ fn state_path() -> Result<PathBuf> {
         .parent()
         .ok_or_else(|| anyhow::anyhow!("invalid user config path"))?;
     Ok(config_dir.join("ai_chat_state.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cached_models_for_key, StateFile};
+
+    #[test]
+    fn legacy_unscoped_model_cache_is_ignored() {
+        let file = StateFile {
+            cached_models: vec!["old-provider-model".to_string()],
+            ..Default::default()
+        };
+
+        assert!(cached_models_for_key(file, "api_key\nhttps://new.example").is_empty());
+    }
+
+    #[test]
+    fn model_cache_is_restored_only_for_matching_endpoint() {
+        let make_file = || StateFile {
+            cached_models: vec!["current-model".to_string()],
+            cached_models_key: Some("api_key\nhttps://current.example".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            cached_models_for_key(make_file(), "api_key\nhttps://current.example"),
+            ["current-model"]
+        );
+        assert!(cached_models_for_key(make_file(), "codex\nhttps://current.example").is_empty());
+    }
 }

--- a/kaku-gui/src/overlay/ai_chat/state.rs
+++ b/kaku-gui/src/overlay/ai_chat/state.rs
@@ -39,6 +39,28 @@ pub(super) fn push_input_snapshot(stack: &mut Vec<InputSnapshot>, input: &str, c
     });
 }
 
+/// Keep the explicitly configured chat model available and prefer it when a
+/// saved selection belongs to a different provider.
+fn reconcile_fetched_models(
+    mut models: Vec<String>,
+    configured_model: &str,
+    saved_model: Option<&str>,
+) -> (Vec<String>, usize) {
+    models.retain(|model| model != configured_model);
+    models.insert(0, configured_model.to_string());
+
+    let model_index = saved_model
+        .filter(|model| *model != crate::codex_connection::FOLLOW_CODEX_MODEL)
+        .and_then(|model| {
+            models
+                .iter()
+                .position(|candidate| candidate.as_str() == model)
+        })
+        .unwrap_or(0);
+
+    (models, model_index)
+}
+
 // ─── Attachment / slash helpers ───────────────────────────────────────────────
 
 pub(super) fn attachment_option_by_label(label: &str) -> Option<AttachmentOption> {
@@ -1127,33 +1149,32 @@ impl App {
                 if list.len() > 30 {
                     list.truncate(30);
                 }
-                // Restore saved model preference. If the saved model is no longer
-                // in the returned list (e.g. provider removed it), surface an error
-                // rather than silently switching to index 0.
-                let saved =
-                    crate::ai_state::load_last_model().unwrap_or_else(|| self.current_model());
-                if saved == crate::codex_connection::FOLLOW_CODEX_MODEL {
-                    self.available_models = list;
-                    self.model_index = 0;
-                    self.model_fetch = ModelFetch::Loaded;
-                    return true;
-                }
-                match list.iter().position(|m| m == &saved) {
-                    Some(idx) => {
-                        self.available_models = list;
-                        self.model_index = idx;
-                        self.model_fetch = ModelFetch::Loaded;
-                    }
-                    None => {
-                        self.available_models = list;
-                        self.model_index = 0;
-                        self.model_fetch = ModelFetch::Failed(format!(
-                            "saved model '{}' is not in the server's model list; \
-                             please select a model manually",
-                            saved
-                        ));
+                // `available_models[0]` is always the model explicitly configured
+                // for this session. A global saved selection may belong to a
+                // previously used provider, so only restore it when the new
+                // provider also advertises it.
+                let configured_model = self
+                    .available_models
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| self.current_model());
+                let saved_model = crate::ai_state::load_last_model();
+                let (models, model_index) =
+                    reconcile_fetched_models(list, &configured_model, saved_model.as_deref());
+                let selected_model = models.get(model_index).cloned().unwrap_or_default();
+
+                if saved_model.as_deref().is_some_and(|saved| {
+                    saved != crate::codex_connection::FOLLOW_CODEX_MODEL
+                        && saved != selected_model.as_str()
+                }) {
+                    if let Err(error) = crate::ai_state::save_last_model(&selected_model) {
+                        log::warn!("Failed to replace stale model selection: {error}");
                     }
                 }
+
+                self.available_models = models;
+                self.model_index = model_index;
+                self.model_fetch = ModelFetch::Loaded;
                 true
             }
             Ok(Err(e)) => {
@@ -2250,6 +2271,42 @@ impl App {
 #[cfg(test)]
 mod responses_state_tests {
     use super::*;
+
+    #[test]
+    fn stale_saved_model_falls_back_to_configured_model() {
+        let (models, index) = reconcile_fetched_models(
+            vec!["glm-4.5".to_string(), "glm-5.3-flash".to_string()],
+            "glm-5.3-flash",
+            Some("deepseek-v4-flash-vision-exp"),
+        );
+
+        assert_eq!(models, ["glm-5.3-flash", "glm-4.5"]);
+        assert_eq!(index, 0);
+    }
+
+    #[test]
+    fn valid_saved_model_remains_selected_after_fetch() {
+        let (models, index) = reconcile_fetched_models(
+            vec!["glm-4.5".to_string(), "glm-5.3-flash".to_string()],
+            "glm-5.3-flash",
+            Some("glm-4.5"),
+        );
+
+        assert_eq!(models, ["glm-5.3-flash", "glm-4.5"]);
+        assert_eq!(index, 1);
+    }
+
+    #[test]
+    fn configured_model_stays_available_when_provider_omits_it() {
+        let (models, index) = reconcile_fetched_models(
+            vec!["provider-default".to_string()],
+            "custom-chat-model",
+            Some("old-provider-model"),
+        );
+
+        assert_eq!(models, ["custom-chat-model", "provider-default"]);
+        assert_eq!(index, 0);
+    }
 
     #[test]
     fn transient_responses_state_never_creates_persistable_assistant_turn() {

--- a/kaku-gui/src/overlay/ai_chat/state.rs
+++ b/kaku-gui/src/overlay/ai_chat/state.rs
@@ -46,8 +46,13 @@ fn reconcile_fetched_models(
     configured_model: &str,
     saved_model: Option<&str>,
 ) -> (Vec<String>, usize) {
-    models.retain(|model| model != configured_model);
-    models.insert(0, configured_model.to_string());
+    let follows_codex = configured_model == crate::codex_connection::FOLLOW_CODEX_MODEL;
+    if follows_codex && models.is_empty() {
+        models.push(configured_model.to_string());
+    } else if !follows_codex {
+        models.retain(|model| model != configured_model);
+        models.insert(0, configured_model.to_string());
+    }
 
     let model_index = saved_model
         .filter(|model| *model != crate::codex_connection::FOLLOW_CODEX_MODEL)
@@ -59,6 +64,23 @@ fn reconcile_fetched_models(
         .unwrap_or(0);
 
     (models, model_index)
+}
+
+fn restored_model_index(
+    models: &[String],
+    saved_model: Option<&str>,
+    list_is_fresh_for_current_provider: bool,
+) -> usize {
+    if !list_is_fresh_for_current_provider {
+        return 0;
+    }
+    saved_model
+        .and_then(|saved| models.iter().position(|model| model == saved))
+        .unwrap_or(0)
+}
+
+fn model_cache_key(base_url: &str, auth_type: &str) -> String {
+    format!("{}\n{}", auth_type, base_url.trim_end_matches('/'))
 }
 
 // ─── Attachment / slash helpers ───────────────────────────────────────────────
@@ -787,7 +809,8 @@ impl App {
                 (vec![chat_model], ModelFetch::Loaded, None)
             }
         } else {
-            let cached = crate::ai_state::load_cached_models();
+            let cache_key = model_cache_key(&client.config().base_url, &client.config().auth_type);
+            let cached = crate::ai_state::load_cached_models(&cache_key);
             let initial_models = if cached.is_empty() {
                 vec![chat_model.clone()]
             } else {
@@ -796,37 +819,29 @@ impl App {
                 models.insert(0, chat_model.clone());
                 models
             };
-            let initial_fetch = if initial_models.len() > 1 {
-                ModelFetch::Loaded
-            } else {
-                ModelFetch::Loading
-            };
             let (tx, rx) = mpsc::channel::<Result<Vec<String>, String>>();
             let fetch_client = client.clone();
             let chat_model_clone = chat_model.clone();
             crate::thread_util::spawn_with_pool(move || {
                 let result = fetch_client.list_models().map_err(|e| e.to_string());
                 if let Ok(ref models) = result {
-                    let mut to_save = models.clone();
-                    to_save.retain(|m| m != &chat_model_clone);
-                    to_save.insert(0, chat_model_clone);
-                    let _ = crate::ai_state::save_cached_models(&to_save);
+                    let (to_save, _) =
+                        reconcile_fetched_models(models.clone(), &chat_model_clone, None);
+                    let _ = crate::ai_state::save_cached_models(&cache_key, &to_save);
                 }
                 let _ = tx.send(result);
             });
-            (initial_models, initial_fetch, Some(rx))
+            (initial_models, ModelFetch::Loading, Some(rx))
         };
 
-        // Restore the last selected model from disk. If it exists in available_models,
-        // rotate the list so it becomes index 0.
-        let model_index = if let Some(last) = crate::ai_state::load_last_model() {
-            available_models
-                .iter()
-                .position(|m| m == &last)
-                .unwrap_or(0)
-        } else {
-            0
-        };
+        // A dynamic cached list may belong to an older account or provider state.
+        // Keep the configured model selected until the current fetch succeeds.
+        let saved_model = crate::ai_state::load_last_model();
+        let model_index = restored_model_index(
+            &available_models,
+            saved_model.as_deref(),
+            model_fetch_rx.is_none(),
+        );
 
         // Ensure there is an active conversation and load its messages.
         // If that fails, try to create a fresh one so the session can still be persisted.
@@ -1161,16 +1176,9 @@ impl App {
                 let saved_model = crate::ai_state::load_last_model();
                 let (models, model_index) =
                     reconcile_fetched_models(list, &configured_model, saved_model.as_deref());
-                let selected_model = models.get(model_index).cloned().unwrap_or_default();
-
-                if saved_model.as_deref().is_some_and(|saved| {
-                    saved != crate::codex_connection::FOLLOW_CODEX_MODEL
-                        && saved != selected_model.as_str()
-                }) {
-                    if let Err(error) = crate::ai_state::save_last_model(&selected_model) {
-                        log::warn!("Failed to replace stale model selection: {error}");
-                    }
-                }
+                // A background refresh may finish after another pane/provider has
+                // saved a newer explicit choice. Reconcile this session in memory;
+                // only direct user actions persist `last_model`.
 
                 self.available_models = models;
                 self.model_index = model_index;
@@ -2306,6 +2314,60 @@ mod responses_state_tests {
 
         assert_eq!(models, ["custom-chat-model", "provider-default"]);
         assert_eq!(index, 0);
+    }
+
+    #[test]
+    fn follow_codex_uses_first_fresh_discovered_model() {
+        let (models, index) = reconcile_fetched_models(
+            vec!["gpt-5.4".to_string(), "gpt-5.3".to_string()],
+            crate::codex_connection::FOLLOW_CODEX_MODEL,
+            Some(crate::codex_connection::FOLLOW_CODEX_MODEL),
+        );
+
+        assert_eq!(models, ["gpt-5.4", "gpt-5.3"]);
+        assert_eq!(index, 0);
+    }
+
+    #[test]
+    fn follow_codex_keeps_sentinel_only_when_discovery_is_empty() {
+        let (models, index) =
+            reconcile_fetched_models(vec![], crate::codex_connection::FOLLOW_CODEX_MODEL, None);
+
+        assert_eq!(models, [crate::codex_connection::FOLLOW_CODEX_MODEL]);
+        assert_eq!(index, 0);
+    }
+
+    #[test]
+    fn stale_cached_list_cannot_restore_a_saved_provider_model() {
+        let models = vec![
+            "configured-model".to_string(),
+            "old-provider-model".to_string(),
+        ];
+
+        assert_eq!(
+            restored_model_index(&models, Some("old-provider-model"), false),
+            0
+        );
+        assert_eq!(
+            restored_model_index(&models, Some("old-provider-model"), true),
+            1
+        );
+    }
+
+    #[test]
+    fn model_cache_key_is_endpoint_scoped_and_normalizes_trailing_slash() {
+        assert_eq!(
+            model_cache_key("https://api.example.com/", "api_key"),
+            model_cache_key("https://api.example.com", "api_key")
+        );
+        assert_ne!(
+            model_cache_key("https://api.example.com", "api_key"),
+            model_cache_key("https://api.example.com", "codex")
+        );
+        assert_ne!(
+            model_cache_key("https://api.example.com", "api_key"),
+            model_cache_key("https://other.example.com", "api_key")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep the explicitly configured chat model at the front of a fetched model list
- restore a saved model only when the current provider also advertises it
- replace a stale cross-provider selection with the configured model instead of showing `(list failed)` and selecting the provider's first model

## Root cause

The chat overlay stores `last_model` globally. After switching providers, a saved model from the previous provider may not exist in the new provider's successful `/models` response. The overlay currently treats that mismatch as a failed model fetch and resets `model_index` to the first server model, even when the configured `chat_model` is present.

## Tests

Added regression coverage for:

- a stale model from another provider falling back to the configured model
- a valid saved model remaining selected
- a manually configured model remaining available when omitted from `/models`
