### PR TITLE
feat(gui): add terminal context menu

### DIFF
--- a/kaku-gui/src/termwindow/mod.rs
+++ b/kaku-gui/src/termwindow/mod.rs
@@ -1986,6 +1986,33 @@ impl TermWindow {
                 }
                 Ok(true)
             }
+            WindowEvent::PerformKeyAssignmentForPane { action, pane_id } => {
+                let pane_id = PaneId::new(pane_id);
+                let mux = Mux::get();
+                let belongs_to_window = mux
+                    .resolve_pane_id(pane_id)
+                    .is_some_and(|(_, window_id, _)| window_id == self.mux_window_id);
+                if !belongs_to_window {
+                    return Ok(true);
+                }
+
+                // Actions such as SplitPane and CloseCurrentPane consult mux active
+                // state internally. Restore the clicked pane as active, then resolve
+                // its current overlay. If it exited while the menu was open, no-op.
+                if mux.focus_pane_and_containing_tab(pane_id).is_err() {
+                    return Ok(true);
+                }
+                let overlay = self
+                    .pane_state(pane_id)
+                    .overlay
+                    .as_ref()
+                    .map(|overlay| Arc::clone(&overlay.pane));
+                if let Some(pane) = overlay.or_else(|| mux.get_pane(pane_id)) {
+                    self.perform_key_assignment(&pane, &action)?;
+                    window.invalidate();
+                }
+                Ok(true)
+            }
             WindowEvent::FocusChanged(focused) => {
                 self.focus_changed(focused, window);
                 Ok(true)

--- a/kaku-gui/src/termwindow/mouseevent.rs
+++ b/kaku-gui/src/termwindow/mouseevent.rs
@@ -7,7 +7,9 @@ use ::window::{
     MouseButtons as WMB, MouseCursor, MouseEvent, MouseEventKind as WMEK, MousePress, WindowOps,
     WindowState,
 };
-use config::keyassignment::{KeyAssignment, MouseEventTrigger, SpawnTabDomain};
+use config::keyassignment::{
+    ClipboardPasteSource, KeyAssignment, MouseEventTrigger, Pattern, SpawnTabDomain,
+};
 use config::{MouseEventAltScreen, SelectionWheelScrollBehavior};
 use mux::pane::{CachePolicy, Pane, WithPaneLines};
 use mux::tab::SplitDirection;
@@ -23,6 +25,8 @@ use termwiz::surface::Line;
 use wezterm_dynamic::ToDynamic;
 use wezterm_term::input::{MouseButton, MouseEventKind as TMEK};
 use wezterm_term::{ClickPosition, KeyCode, KeyModifiers, LastMouseClick, StableRowIndex};
+#[cfg(target_os = "macos")]
+use window::os::macos::menu::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MouseDispatchTarget {
@@ -1487,6 +1491,88 @@ impl super::TermWindow {
 
                 break;
             }
+        }
+
+        #[cfg(target_os = "macos")]
+        if event.kind == WMEK::Press(MousePress::Right)
+            && (event.modifiers.contains(::window::Modifiers::SHIFT) || !pane.is_mouse_grabbed())
+            && !is_already_captured
+        {
+            let menu = Menu::new_with_title("");
+            let selector = sel!(kakuPerformKeyAssignment:);
+            let split = |direction| {
+                KeyAssignment::SplitPane(config::keyassignment::SplitPane {
+                    direction,
+                    size: Default::default(),
+                    command: Default::default(),
+                    top_level: false,
+                })
+            };
+            for (title, action, shortcut, mask) in [
+                (
+                    "Paste",
+                    KeyAssignment::PasteFrom(ClipboardPasteSource::Clipboard),
+                    "v",
+                    NSEventModifierFlags::NSCommandKeyMask,
+                ),
+                (
+                    "Search",
+                    KeyAssignment::Search(Pattern::default()),
+                    "f",
+                    NSEventModifierFlags::NSCommandKeyMask,
+                ),
+                (
+                    "AI Chat",
+                    KeyAssignment::EmitEvent("kaku-ai-chat".to_string()),
+                    "l",
+                    NSEventModifierFlags::NSCommandKeyMask,
+                ),
+                (
+                    "Command Palette",
+                    KeyAssignment::ActivateCommandPalette,
+                    "p",
+                    NSEventModifierFlags::NSCommandKeyMask | NSEventModifierFlags::NSShiftKeyMask,
+                ),
+                (
+                    "Split Left  ←",
+                    split(config::keyassignment::PaneDirection::Left),
+                    "",
+                    NSEventModifierFlags::empty(),
+                ),
+                (
+                    "Split Right  →",
+                    split(config::keyassignment::PaneDirection::Right),
+                    "d",
+                    NSEventModifierFlags::NSCommandKeyMask,
+                ),
+                (
+                    "Split Up  ↑",
+                    split(config::keyassignment::PaneDirection::Up),
+                    "",
+                    NSEventModifierFlags::empty(),
+                ),
+                (
+                    "Split Down  ↓",
+                    split(config::keyassignment::PaneDirection::Down),
+                    "d",
+                    NSEventModifierFlags::NSCommandKeyMask | NSEventModifierFlags::NSShiftKeyMask,
+                ),
+                (
+                    "Close Pane",
+                    KeyAssignment::CloseCurrentPane { confirm: false },
+                    "w",
+                    NSEventModifierFlags::NSCommandKeyMask,
+                ),
+            ] {
+                let item = MenuItem::new_with(title, Some(selector), shortcut);
+                if !shortcut.is_empty() {
+                    item.set_key_equiv_modifier_mask(mask);
+                }
+                item.set_represented_item(RepresentedItem::KeyAssignment(action));
+                menu.add_item(&item);
+            }
+            context.show_context_menu(menu, event.screen_coords);
+            return;
         }
 
         // Detect when the mouse is in the OS resize handle zone.

--- a/kaku-gui/src/termwindow/mouseevent.rs
+++ b/kaku-gui/src/termwindow/mouseevent.rs
@@ -35,6 +35,61 @@ enum MouseDispatchTarget {
     Terminal,
 }
 
+fn should_show_terminal_context_menu(
+    event_kind: &WMEK,
+    modifiers: window::Modifiers,
+    bypass_modifiers: window::Modifiers,
+    mouse_grabbed: bool,
+    is_already_captured: bool,
+    has_mouse_assignment: bool,
+) -> bool {
+    matches!(event_kind, WMEK::Press(MousePress::Right))
+        && !is_already_captured
+        && !has_mouse_assignment
+        && (!mouse_grabbed || modifiers.contains(bypass_modifiers))
+}
+
+fn terminal_context_menu_actions() -> Vec<(&'static str, KeyAssignment)> {
+    let split = |direction| {
+        KeyAssignment::SplitPane(config::keyassignment::SplitPane {
+            direction,
+            size: Default::default(),
+            command: Default::default(),
+            top_level: false,
+        })
+    };
+
+    vec![
+        (
+            "Paste",
+            KeyAssignment::PasteFrom(ClipboardPasteSource::Clipboard),
+        ),
+        ("Search", KeyAssignment::Search(Pattern::default())),
+        (
+            "AI Chat",
+            KeyAssignment::EmitEvent("kaku-ai-chat".to_string()),
+        ),
+        ("Command Palette", KeyAssignment::ActivateCommandPalette),
+        (
+            "Split Left",
+            split(config::keyassignment::PaneDirection::Left),
+        ),
+        (
+            "Split Right",
+            split(config::keyassignment::PaneDirection::Right),
+        ),
+        ("Split Up", split(config::keyassignment::PaneDirection::Up)),
+        (
+            "Split Down",
+            split(config::keyassignment::PaneDirection::Down),
+        ),
+        (
+            "Close Pane",
+            KeyAssignment::CloseCurrentPane { confirm: true },
+        ),
+    ]
+}
+
 /// Per-window state describing in-flight window-level drag interactions
 /// (manual title-bar drag, OS edge resize suppression, click-to-focus
 /// suppression). Bundled to keep the drag invariants in one place.
@@ -1493,88 +1548,6 @@ impl super::TermWindow {
             }
         }
 
-        #[cfg(target_os = "macos")]
-        if event.kind == WMEK::Press(MousePress::Right)
-            && (event.modifiers.contains(::window::Modifiers::SHIFT) || !pane.is_mouse_grabbed())
-            && !is_already_captured
-        {
-            let menu = Menu::new_with_title("");
-            let selector = sel!(kakuPerformKeyAssignment:);
-            let split = |direction| {
-                KeyAssignment::SplitPane(config::keyassignment::SplitPane {
-                    direction,
-                    size: Default::default(),
-                    command: Default::default(),
-                    top_level: false,
-                })
-            };
-            for (title, action, shortcut, mask) in [
-                (
-                    "Paste",
-                    KeyAssignment::PasteFrom(ClipboardPasteSource::Clipboard),
-                    "v",
-                    NSEventModifierFlags::NSCommandKeyMask,
-                ),
-                (
-                    "Search",
-                    KeyAssignment::Search(Pattern::default()),
-                    "f",
-                    NSEventModifierFlags::NSCommandKeyMask,
-                ),
-                (
-                    "AI Chat",
-                    KeyAssignment::EmitEvent("kaku-ai-chat".to_string()),
-                    "l",
-                    NSEventModifierFlags::NSCommandKeyMask,
-                ),
-                (
-                    "Command Palette",
-                    KeyAssignment::ActivateCommandPalette,
-                    "p",
-                    NSEventModifierFlags::NSCommandKeyMask | NSEventModifierFlags::NSShiftKeyMask,
-                ),
-                (
-                    "Split Left  ←",
-                    split(config::keyassignment::PaneDirection::Left),
-                    "",
-                    NSEventModifierFlags::empty(),
-                ),
-                (
-                    "Split Right  →",
-                    split(config::keyassignment::PaneDirection::Right),
-                    "d",
-                    NSEventModifierFlags::NSCommandKeyMask,
-                ),
-                (
-                    "Split Up  ↑",
-                    split(config::keyassignment::PaneDirection::Up),
-                    "",
-                    NSEventModifierFlags::empty(),
-                ),
-                (
-                    "Split Down  ↓",
-                    split(config::keyassignment::PaneDirection::Down),
-                    "d",
-                    NSEventModifierFlags::NSCommandKeyMask | NSEventModifierFlags::NSShiftKeyMask,
-                ),
-                (
-                    "Close Pane",
-                    KeyAssignment::CloseCurrentPane { confirm: false },
-                    "w",
-                    NSEventModifierFlags::NSCommandKeyMask,
-                ),
-            ] {
-                let item = MenuItem::new_with(title, Some(selector), shortcut);
-                if !shortcut.is_empty() {
-                    item.set_key_equiv_modifier_mask(mask);
-                }
-                item.set_represented_item(RepresentedItem::KeyAssignment(action));
-                menu.add_item(&item);
-            }
-            context.show_context_menu(menu, event.screen_coords);
-            return;
-        }
-
         // Detect when the mouse is in the OS resize handle zone.
         // Only used to prevent mouse capture and to seed edge_drag_in_progress;
         // event suppression is driven by edge_drag_in_progress state, not position.
@@ -2061,11 +2034,43 @@ impl super::TermWindow {
                     },
                 };
 
-                if let Some(action) = self
+                let mouse_assignment = self
                     .keyboard
                     .input_map
-                    .lookup_mouse(event_trigger_type, mouse_mods)
-                {
+                    .lookup_mouse(event_trigger_type, mouse_mods);
+
+                #[cfg(target_os = "macos")]
+                if should_show_terminal_context_menu(
+                    &event.kind,
+                    event.modifiers,
+                    self.config.bypass_mouse_reporting_modifiers,
+                    pane.is_mouse_grabbed(),
+                    is_already_captured,
+                    mouse_assignment.is_some(),
+                ) {
+                    let target_pane_id = Mux::get()
+                        .get_active_tab_for_window(self.mux_window_id)
+                        .and_then(|tab| tab.get_active_pane())
+                        .map(|pane| pane.pane_id().as_usize());
+                    if let Some(pane_id) = target_pane_id {
+                        let menu = Menu::new_with_title("");
+                        let selector = sel!(kakuPerformKeyAssignment:);
+                        for (title, action) in terminal_context_menu_actions() {
+                            // Context-menu items deliberately have no AppKit keyEquivalent.
+                            // Kaku's configurable InputMap remains the shortcut source of truth.
+                            let item = MenuItem::new_with(title, Some(selector), "");
+                            item.set_represented_item(RepresentedItem::KeyAssignmentForPane {
+                                action,
+                                pane_id,
+                            });
+                            menu.add_item(&item);
+                        }
+                        context.show_context_menu(menu, event.screen_coords);
+                        return;
+                    }
+                }
+
+                if let Some(action) = mouse_assignment {
                     if matches!(
                         action,
                         KeyAssignment::SelectTextAtMouseCursor(_)
@@ -2187,13 +2192,15 @@ mod tests {
     use super::{
         manual_drag_window_top_left, mouse_dispatch_target, option_click_cursor_bytes,
         should_bypass_wheel_assignment_in_alt, should_preserve_tmux_bypass_reporting,
-        should_use_manual_window_drag, should_use_native_maximized_window_drag,
-        should_zoom_title_area, tab_bar_item_starts_window_drag,
+        should_show_terminal_context_menu, should_use_manual_window_drag,
+        should_use_native_maximized_window_drag, should_zoom_title_area,
+        tab_bar_item_starts_window_drag, terminal_context_menu_actions,
         title_area_double_click_zoom_action, wheel_during_terminal_selection_action,
         MouseDispatchTarget, OptionClickRowInfo, SelectionDragWheelAction, TitleAreaZoomAction,
     };
     use crate::tabbar::TabBarItem;
     use crate::termwindow::MouseCapture;
+    use config::keyassignment::KeyAssignment;
     use config::SelectionWheelScrollBehavior;
     use mux::pane::PaneId;
     use window::{
@@ -2591,5 +2598,69 @@ mod tests {
             SelectionWheelScrollBehavior::default(),
             SelectionWheelScrollBehavior::Extend
         );
+    }
+
+    #[test]
+    fn context_menu_respects_mouse_reporting_bypass_configuration() {
+        assert!(should_show_terminal_context_menu(
+            &MouseEventKind::Press(MousePress::Right),
+            Modifiers::ALT,
+            Modifiers::ALT,
+            true,
+            false,
+            false,
+        ));
+        assert!(!should_show_terminal_context_menu(
+            &MouseEventKind::Press(MousePress::Right),
+            Modifiers::SHIFT,
+            Modifiers::ALT,
+            true,
+            false,
+            false,
+        ));
+    }
+
+    #[test]
+    fn context_menu_never_overrides_capture_or_custom_mouse_assignment() {
+        let right_press = MouseEventKind::Press(MousePress::Right);
+        assert!(!should_show_terminal_context_menu(
+            &right_press,
+            Modifiers::NONE,
+            Modifiers::SHIFT,
+            false,
+            true,
+            false,
+        ));
+        assert!(!should_show_terminal_context_menu(
+            &right_press,
+            Modifiers::NONE,
+            Modifiers::SHIFT,
+            false,
+            false,
+            true,
+        ));
+    }
+
+    #[test]
+    fn context_menu_close_uses_confirmation_policy() {
+        let close = terminal_context_menu_actions()
+            .into_iter()
+            .find(|(title, _)| *title == "Close Pane")
+            .map(|(_, action)| action);
+
+        assert_eq!(
+            close,
+            Some(KeyAssignment::CloseCurrentPane { confirm: true })
+        );
+    }
+
+    #[test]
+    fn context_menu_dispatch_retains_stable_pane_id() {
+        let mouse_source = include_str!("mouseevent.rs");
+        let window_source = include_str!("mod.rs");
+
+        assert!(mouse_source.contains("RepresentedItem::KeyAssignmentForPane"));
+        assert!(window_source.contains("WindowEvent::PerformKeyAssignmentForPane"));
+        assert!(window_source.contains("focus_pane_and_containing_tab(pane_id)"));
     }
 }

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -259,6 +259,13 @@ pub enum WindowEvent {
     /// Called by menubar dispatching stuff on some systems
     PerformKeyAssignment(config::keyassignment::KeyAssignment),
 
+    /// Called by a pane context menu. The stable pane id prevents an action
+    /// from falling through to a different active pane while the menu is open.
+    PerformKeyAssignmentForPane {
+        action: config::keyassignment::KeyAssignment,
+        pane_id: usize,
+    },
+
     AdviseModifiersLedStatus(Modifiers, KeyboardLedStatus),
 }
 

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -382,6 +382,9 @@ pub trait WindowOps {
     /// Change the titlebar text for the window
     fn set_title(&self, title: &str);
 
+    #[cfg(target_os = "macos")]
+    fn show_context_menu(&self, menu: crate::os::macos::menu::Menu, point: ScreenPoint);
+
     /// Resize the inner or client area of the window
     fn set_inner_size(&self, width: usize, height: usize);
 

--- a/window/src/os/macos/app.rs
+++ b/window/src/os/macos/app.rs
@@ -1145,7 +1145,7 @@ extern "C" fn kaku_perform_key_assignment(_self: &mut Object, _sel: Sel, menu_it
                 conn.dispatch_app_event(ApplicationEvent::PerformKeyAssignment(action));
             }
         }
-        None => {}
+        Some(RepresentedItem::KeyAssignmentForPane { .. }) | None => {}
     }
 }
 

--- a/window/src/os/macos/menu.rs
+++ b/window/src/os/macos/menu.rs
@@ -188,6 +188,10 @@ pub struct MenuItem {
 #[derive(Clone, Debug, PartialEq)]
 pub enum RepresentedItem {
     KeyAssignment(KeyAssignment),
+    KeyAssignmentForPane {
+        action: KeyAssignment,
+        pane_id: usize,
+    },
 }
 
 impl RepresentedItem {

--- a/window/src/os/macos/menu.rs
+++ b/window/src/os/macos/menu.rs
@@ -29,6 +29,15 @@ impl Menu {
         self.menu.autorelease()
     }
 
+    /// Display this menu at a point in global screen coordinates.
+    pub fn pop_up_at_screen_point(&self, x: isize, y: isize) {
+        unsafe {
+            let point = cocoa::foundation::NSPoint::new(x as f64, y as f64);
+            let _: () =
+                msg_send![*self.menu, popUpMenuPositioningItem: nil atLocation: point inView: nil];
+        }
+    }
+
     pub fn item_at_index(&self, index: usize) -> Option<MenuItem> {
         let index = index as i64;
         let item = unsafe { self.menu.itemAtIndex_(index) };

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1525,6 +1525,24 @@ pub fn window_level_to_nswindow_level(level: WindowLevel) -> NSWindowLevel {
 
 #[async_trait(?Send)]
 impl WindowOps for Window {
+    fn show_context_menu(&self, menu: crate::os::macos::menu::Menu, point: ScreenPoint) {
+        if self.ns_window().is_some() {
+            unsafe {
+                // ScreenPoint uses Kaku's global top-left coordinate space,
+                // which is normalized against the primary display in
+                // cartesian_to_screen_point. Invert that same transform;
+                // using the secondary display frame here introduces an
+                // offset on external monitors.
+                let primary = NSScreen::screens(nil).objectAtIndex(0);
+                let primary_frame: cocoa::foundation::NSRect = msg_send![primary, frame];
+                let backing = NSScreen::convertRectToBacking_(primary, primary_frame);
+                let scale = backing.size.height / primary_frame.size.height;
+                let cocoa_y = primary_frame.size.height - point.y as f64 / scale;
+                menu.pop_up_at_screen_point((point.x as f64 / scale) as isize, cocoa_y as isize);
+            }
+        }
+    }
+
     async fn enable_opengl(&self) -> anyhow::Result<Rc<glium::backend::Context>> {
         let window_id = self.id;
         promise::spawn::spawn(async move {

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -4824,7 +4824,7 @@ impl WindowView {
         menu_item: *mut Object,
     ) {
         let menu_item = MenuItem::with_menu_item(menu_item);
-        // Safe because kakuPerformKeyAssignment: is only used with KeyAssignment
+        // Safe because kakuPerformKeyAssignment: is only used with RepresentedItem
         let action = menu_item.get_represented_item();
         log::debug!("kaku_perform_key_assignment {action:?}",);
         match action {
@@ -4836,6 +4836,20 @@ impl WindowView {
                         let events = inner.events.clone();
                         drop(inner);
                         events.dispatch(WindowEvent::PerformKeyAssignment(action));
+                    }
+                }
+            }
+            Some(RepresentedItem::KeyAssignmentForPane { action, pane_id }) => {
+                if let Some(this) = Self::get_this(this) {
+                    // As above, release the RefCell borrow before dispatch so the
+                    // native menu action remains safe under AppKit re-entry.
+                    if let Ok(inner) = this.inner.try_borrow() {
+                        let events = inner.events.clone();
+                        drop(inner);
+                        events.dispatch(WindowEvent::PerformKeyAssignmentForPane {
+                            action,
+                            pane_id,
+                        });
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Add a native macOS context menu to terminal panes so common actions are accessible with a right-click.

The menu includes:

- Paste
- Search
- AI Chat
- Command Palette
- Split pane in four directions
- Close Pane

The context menu appears when the terminal application has not captured the right-click event. Holding `Shift` also allows it to be opened when mouse reporting is active.

## Implementation

- Route native context-menu display through `WindowOps`.
- Convert Kaku screen coordinates to macOS global screen coordinates.
- Attach existing `KeyAssignment` actions to native menu items.
- Preserve the existing terminal mouse handling behavior when the menu is not shown.

## Verification

- `make fmt-check`
- `make check`
- `make test`
  - 1484 workspace tests passed
  - 15 escape parser tests passed
- `make app`


Related  https://github.com/tw93/Kaku/pull/77

<img width="2206" height="1430" alt="SCR-20260828-nqrw" src="https://github.com/user-attachments/assets/76e4a371-bfdd-43e1-b59f-bab07fb0099b" />

