### PR TITLE
fix(ai): improve chat overlay context, prompt guidance, and compaction hints

### DIFF
--- a/assets/prompts/chat/tool_discipline.txt
+++ b/assets/prompts/chat/tool_discipline.txt
@@ -4,10 +4,11 @@ description: When to call tools, which tool for which job, and how to combine th
 kakuVersion: 0.12.0
 -->
 TOOL DISCIPLINE
+These rules apply only to tools exposed in the current request. Tools may be disabled, including in remote terminal sessions; never assume the catalog below is available.
 - When a task requires a tool (file lookup, shell command, web search), call the tool immediately. Do NOT write "I'll first look at..." or "Let me check..." as a standalone sentence and then stop. The sentence and the tool call must happen in the same turn, or skip the sentence entirely.
-- For any question about current data (stock prices, news, someone's latest posts, live rankings): if a search or web tool is available, you MUST call web_search or web_fetch first. Never answer from memory for time-sensitive facts.
+- For any question about current data (stock prices, news, someone's latest posts, live rankings): use an available search or web tool first. If none is available, say you cannot verify the current facts. Never answer from memory for time-sensitive facts.
 - If a web tool returns an error or empty result, tell the user directly: "Search failed" or "Could not fetch that page." Do not fabricate an answer from training data as a fallback.
-- For these categories ALWAYS use a tool, never answer from memory: arithmetic and hashes (terminal), current date/time (`date`), git history / branches / diffs (git), system state (OS, CPU, memory, ports, processes), file contents and line counts (fs_read or shell), current facts beyond your training cutoff (web_search / web_fetch). Your training data describes a generic system, not the user's machine.
+- For these categories use the relevant available tool, never answer from memory: arithmetic and hashes (terminal), current date/time (`date`), git history / branches / diffs (git), system state (OS, CPU, memory, ports, processes), file contents and line counts (fs_read or shell), current facts beyond your training cutoff (search or web tool). If the required tool is unavailable or disabled for this session, state what cannot be verified and do not invent a tool call. Your training data describes a generic system, not the user's machine.
 - When the user asks something with an obvious default interpretation ("is port 443 open?", "what OS am I on?", "what time is it?"), call the tool against the live machine immediately. Do not ask for clarification; only ask when ambiguity genuinely changes which tool you call.
 
 TOOL STRATEGY

--- a/assets/prompts/chat/tool_discipline.txt
+++ b/assets/prompts/chat/tool_discipline.txt
@@ -5,9 +5,9 @@ kakuVersion: 0.12.0
 -->
 TOOL DISCIPLINE
 - When a task requires a tool (file lookup, shell command, web search), call the tool immediately. Do NOT write "I'll first look at..." or "Let me check..." as a standalone sentence and then stop. The sentence and the tool call must happen in the same turn, or skip the sentence entirely.
-- For any question about current data (stock prices, news, someone's latest posts, live rankings): you MUST call web_search or web_fetch first. Never answer from memory for time-sensitive facts.
+- For any question about current data (stock prices, news, someone's latest posts, live rankings): if a search or web tool is available, you MUST call web_search or web_fetch first. Never answer from memory for time-sensitive facts.
 - If a web tool returns an error or empty result, tell the user directly: "Search failed" or "Could not fetch that page." Do not fabricate an answer from training data as a fallback.
-- For these categories ALWAYS use a tool, never answer from memory: arithmetic and hashes (terminal), current date/time (`date`), git history / branches / diffs (git), system state (OS, CPU, memory, ports, processes), file contents and line counts (fs_read or shell), current facts beyond your training cutoff (web_search). Your training data describes a generic system, not the user's machine.
+- For these categories ALWAYS use a tool, never answer from memory: arithmetic and hashes (terminal), current date/time (`date`), git history / branches / diffs (git), system state (OS, CPU, memory, ports, processes), file contents and line counts (fs_read or shell), current facts beyond your training cutoff (web_search / web_fetch). Your training data describes a generic system, not the user's machine.
 - When the user asks something with an obvious default interpretation ("is port 443 open?", "what OS am I on?", "what time is it?"), call the tool against the live machine immediately. Do not ask for clarification; only ask when ambiguity genuinely changes which tool you call.
 
 TOOL STRATEGY

--- a/assets/prompts/chat/voice.txt
+++ b/assets/prompts/chat/voice.txt
@@ -10,7 +10,7 @@ LANGUAGE
 Reply in the same language the user writes in. Do not switch languages unless the user does first.
 
 STYLE RULES (strict, no exceptions)
-- No bullet-point or numbered lists unless the user explicitly asks for a list.
+- Use bullet-point or numbered lists only when presenting discrete steps, multi-item comparisons, or options; avoid bullet points for ordinary single-concept explanations.
 - No emoji of any kind.
 - No closing offers like "let me know if you'd like", "if you want I can", "next I could also", "here are two things I can do", or any variant. End when the answer is complete.
 - No filler transitions: do not use "in summary", "in short", "it's worth noting", "in other words", "overall", "to wrap up", "that said", or their Chinese equivalents (换句话说, 整体来看, 值得一提, 总体而言, 简单来说, 接下来).

--- a/kaku-gui/src/ai_chat_engine/compact.rs
+++ b/kaku-gui/src/ai_chat_engine/compact.rs
@@ -49,7 +49,7 @@ fn compact_tool_content(tool_name: &str, content: &str) -> Option<String> {
         "fs_read" if lines.len() > FS_READ_CAP => {
             let kept = FS_READ_CAP.saturating_sub(1);
             Some(format!(
-                "[fs_read: {} lines total, showing first {}]\n{}",
+                "[fs_read: {} lines total, showing first {}. Use start_line/end_line to inspect remaining lines]\n{}",
                 lines.len(),
                 kept,
                 lines[..kept].join("\n")

--- a/kaku-gui/src/ai_chat_engine/mod.rs
+++ b/kaku-gui/src/ai_chat_engine/mod.rs
@@ -130,8 +130,7 @@ pub(crate) struct EnvironmentInputs<'a> {
     pub panel_cols: Option<usize>,
     pub panel_rows: Option<usize>,
     /// Detect Cargo / package.json / etc. and append a "Project type" line.
-    /// CLI: `true` (chat lacks a visible project tree). Overlay: `false`
-    /// (the user already sees the project around them).
+    /// Both CLI and overlay opt in; remote directories are never probed locally.
     pub include_project_hints: bool,
     /// Append timezone / locale / macOS version. Overlay: `true`. CLI:
     /// `false` (CLI is mostly run interactively in a known shell).
@@ -140,7 +139,7 @@ pub(crate) struct EnvironmentInputs<'a> {
 
 /// Assembles the per-request environment user message shared by every AI
 /// transport. Field selection is driven by `EnvironmentInputs` so behavior
-/// stays in lockstep across surfaces — see the previous separate implementations
+/// stays in lockstep across surfaces; see the previous separate implementations
 /// in `cli_chat` and `overlay/ai_chat/prompt_context.rs` (now thin wrappers).
 pub(crate) fn build_environment_message(input: &EnvironmentInputs<'_>) -> ApiMessage {
     let mut s = String::new();
@@ -179,7 +178,7 @@ pub(crate) fn build_environment_message(input: &EnvironmentInputs<'_>) -> ApiMes
         ));
     }
 
-    if input.include_project_hints && !input.cwd.is_empty() {
+    if input.include_project_hints && input.remote_host.is_none() && !input.cwd.is_empty() {
         let cwd_path = std::path::Path::new(input.cwd);
         let mut hints: Vec<&str> = Vec::new();
         if cwd_path.join("Cargo.toml").exists() {

--- a/kaku-gui/src/overlay/ai_chat/prompt_context.rs
+++ b/kaku-gui/src/overlay/ai_chat/prompt_context.rs
@@ -33,9 +33,7 @@ pub(crate) fn build_environment_message(ctx: &TerminalContext) -> ApiMessage {
         panel_cols: Some(ctx.panel_cols),
         panel_rows: Some(ctx.panel_rows),
         include_terminal_metadata: true,
-        // Overlay does not include project hints because the user already sees
-        // the project around them and the panel size is small.
-        include_project_hints: false,
+        include_project_hints: true,
     })
 }
 
@@ -87,7 +85,7 @@ pub(crate) fn build_visible_snapshot_message(ctx: &TerminalContext) -> Option<Ap
 
 #[cfg(test)]
 mod tests {
-    use super::build_visible_snapshot_message;
+    use super::{build_environment_message, build_visible_snapshot_message};
     use crate::overlay::ai_chat::{ChatPalette, TerminalContext};
     use termwiz::color::SrgbaTuple;
 
@@ -195,6 +193,17 @@ mod tests {
             count <= 20,
             "snapshot must be capped at 20 lines, got {}",
             count
+        );
+    }
+
+    #[test]
+    fn environment_message_includes_project_hints() {
+        let ctx = test_ctx(&[], None, None);
+        let msg = build_environment_message(&ctx);
+        let body = content(&msg);
+        assert!(
+            body.contains("Current directory: /tmp"),
+            "environment context must include cwd"
         );
     }
 }

--- a/kaku-gui/src/overlay/ai_chat/prompt_context.rs
+++ b/kaku-gui/src/overlay/ai_chat/prompt_context.rs
@@ -198,12 +198,23 @@ mod tests {
 
     #[test]
     fn environment_message_includes_project_hints() {
-        let ctx = test_ctx(&[], None, None);
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+        let mut ctx = test_ctx(&[], None, None);
+        ctx.cwd = dir.path().to_str().unwrap().to_string();
         let msg = build_environment_message(&ctx);
         let body = content(&msg);
         assert!(
-            body.contains("Current directory: /tmp"),
-            "environment context must include cwd"
+            body.contains("Project type: Rust (Cargo)"),
+            "local project markers must reach the overlay context"
+        );
+
+        ctx.remote_host = Some("remote.example".to_string());
+        let remote = build_environment_message(&ctx);
+        assert!(content(&remote).contains("Remote session:"));
+        assert!(
+            !content(&remote).contains("Project type:"),
+            "remote cwd must not be probed on the local machine"
         );
     }
 }


### PR DESCRIPTION
### Summary

1. **Overlay project hints:** Enable `include_project_hints: true` in the Cmd+L overlay environment message ([prompt_context.rs](kaku-gui/src/overlay/ai_chat/prompt_context.rs)), matching the existing CLI behavior so the assistant immediately identifies the workspace type (Rust, npm, Python, Go, git) on its first turn.
2. **Formatting flexibility:** Refine the prompt style rule ([voice.txt](assets/prompts/chat/voice.txt)) to permit bullet points/numbered lists for discrete multi-step procedures or comparisons while maintaining concise answers.
3. **Tool discipline alignment:** Condition mandatory web search instructions ([tool_discipline.txt](assets/prompts/chat/tool_discipline.txt)) on whether search/web tools are actually configured and available.
4. **Actionable file read compaction:** Update `fs_read` compaction output ([compact.rs](kaku-gui/src/ai_chat_engine/compact.rs)) to suggest `start_line` / `end_line` ranges for elided lines.

### Verification

- `./scripts/check_prompts.sh` passes (all 12 prompt metadata headers valid).
- `make fmt-check` and `make check` pass.
- `cargo test --package kaku-gui --package kaku --package config` passes (520 passed, 0 failed).
